### PR TITLE
Updated reconnecting-websocket version and available options

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,15 +102,18 @@ const client = dcrf.connect('wss://example.com', {
   },
 
   // Options to be passed to ReconnectingWebsocket
-  // See https://github.com/pladaria/reconnecting-websocket#configure for more info
+  // See https://github.com/pladaria/reconnecting-websocket#available-options for more info
   websocket: {
-    constructor: isGlobalWebSocket() ? WebSocket : null,
-    maxReconnectionDelay: 10000,
-    minReconnectionDelay: 1500,
-    reconnectionDelayGrowFactor: 1.3,
-    connectionTimeout: 4000,
-    maxRetries: Infinity,
-    debug: false,
+    WebSocket?: any; // WebSocket constructor, if none provided, defaults to global WebSocket
+    maxReconnectionDelay?: number; // max delay in ms between reconnections
+    minReconnectionDelay?: number; // min delay in ms between reconnections
+    reconnectionDelayGrowFactor?: number; // how fast the reconnection delay grows
+    minUptime?: number; // min time in ms to consider connection as stable
+    connectionTimeout?: number; // retry connect if not connected after this time, in ms
+    maxRetries?: number; // maximum number of retries
+    maxEnqueuedMessages?: number; // maximum number of messages to buffer until reconnection
+    startClosed?: boolean; // start websocket in CLOSED state, call `.reconnect()` to connect
+    debug?: boolean; // enables debug output
   }
 });
 ```

--- a/package.json
+++ b/package.json
@@ -61,6 +61,6 @@
     "lodash.ismatch": "^4.4.0",
     "lodash.pull": "^4.1.0",
     "loglevel": "^1.6.1",
-    "reconnecting-websocket": "^4.1.10"
+    "reconnecting-websocket": "^4.4.0"
   }
 }

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1,3 +1,5 @@
+import { Options as ReconnectingWebsocketOptions } from 'reconnecting-websocket';
+
 export
 interface IMessageEvent {
   data: string
@@ -326,12 +328,5 @@ interface IDCRFOptions {
   preprocessMessage?: MessagePreprocessor,
 
   // ReconnectingWebsocket options
-  websocket?: {
-    maxReconnectionDelay?: number,
-    minReconnectionDelay?: number,
-    reconnectionDelayGrowFactor?: number,
-    connectionTimeout?: number,
-    maxRetries?: number,
-    debug?: boolean,
-  }
+  websocket?: ReconnectingWebsocketOptions
 }


### PR DESCRIPTION
Hey man... updated the reconnecting-websocket version and options so i can send a custom WS class when using on node. Also the previous README was mentioning a "constructor" option that was not available.

Hope it can help!

By the way, GREAT MODULE.... very helpful!