### PR TITLE
Subscribe pull request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dcrf-client",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -278,8 +278,7 @@
     "@types/lodash": {
       "version": "4.14.123",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.123.tgz",
-      "integrity": "sha512-pQvPkc4Nltyx7G1Ww45OjVqUsJP4UsZm+GWJpigXgkikZqJgRm4c48g027o6tdgubWHwFRF15iFd+Y4Pmqv6+Q==",
-      "dev": true
+      "integrity": "sha512-pQvPkc4Nltyx7G1Ww45OjVqUsJP4UsZm+GWJpigXgkikZqJgRm4c48g027o6tdgubWHwFRF15iFd+Y4Pmqv6+Q=="
     },
     "@types/lodash.ismatch": {
       "version": "4.4.6",
@@ -295,6 +294,14 @@
       "resolved": "https://registry.npmjs.org/@types/lodash.pull/-/lodash.pull-4.1.6.tgz",
       "integrity": "sha512-pK+efqDL+Of68Gqd81LfOdBAmB5X6+SHM6kkUTTFQWqOPAomn3BWJcASLrr998SRE7aYLnDVmM5wLLbS7T159A==",
       "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
+    "@types/lodash.uniqby": {
+      "version": "4.7.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash.uniqby/-/lodash.uniqby-4.7.6.tgz",
+      "integrity": "sha512-9wBhrm1y6asW50Joj6tsySCNUgzK2tCqL7vtKIej0E9RyeBFdcte7fxUosmFuMoOU0eHqOMK76kCCrK99jxHgg==",
       "requires": {
         "@types/lodash": "*"
       }
@@ -1113,6 +1120,11 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/lodash.pull/-/lodash.pull-4.1.0.tgz",
       "integrity": "sha1-YAYMxr1iW01FZ+wn3EXNG+nuwBI="
+    },
+    "lodash.uniqby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+      "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI="
     },
     "log-symbols": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -60,9 +60,11 @@
     "ws": "^6.2.0"
   },
   "dependencies": {
+    "@types/lodash.uniqby": "^4.7.6",
     "autobind-decorator": "^2.4.0",
     "lodash.ismatch": "^4.4.0",
     "lodash.pull": "^4.1.0",
+    "lodash.uniqby": "^4.7.0",
     "loglevel": "^1.6.1",
     "reconnecting-websocket": "^4.4.0"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import JSONSerializer from './serializers/json';
 
 import {SubscriptionPromise} from './subscriptions';
 import WebsocketTransport from './transports/websocket';
+import {uniqBy} from "lodash";
 
 
 const log = getLogger('dcrf');
@@ -233,11 +234,15 @@ class DCRFClient implements IStreamingAPI {
    * Send subscription requests for all registered subscriptions
    */
   public resubscribe() {
-    const subscriptions: Array<{message: object}> = Object.values(this.subscriptions);
+    const subscriptions: Array<ISubscriptionDescriptor<any, any>> = Object.values(this.subscriptions);
+    const resubscribeMessages = uniqBy(subscriptions, (s) => {
+      // @ts-ignore
+      return s.message.payload.request_id
+    })
 
     log.info('Resending %d subscription requests', subscriptions.length);
 
-    for (const {message} of subscriptions) {
+    for (const {message} of resubscribeMessages) {
       this.sendNow(message);
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -221,7 +221,7 @@ class DCRFClient implements IStreamingAPI {
     const unsubscribe = async () => {
       const create = createListenerId ? this.unsubscribe(createListenerId) : false;
       const subbed = create || this.unsubscribe(updateListenerId) || this.unsubscribe(deleteListenerId);
-      await this.request(stream, unsubscribeMessage, requestId)
+      await this.request(stream, unsubscribePayload, requestId)
       return subbed;
     };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ import JSONSerializer from './serializers/json';
 
 import {SubscriptionPromise} from './subscriptions';
 import WebsocketTransport from './transports/websocket';
-import {uniqBy} from "lodash";
+import uniqBy from "lodash.uniqby";
 
 
 const log = getLogger('dcrf');

--- a/src/index.ts
+++ b/src/index.ts
@@ -206,7 +206,7 @@ class DCRFClient implements IStreamingAPI {
     const unsubscribePayload = this.buildUnsubscribePayload(options.unsubscribeAction, args, requestId);
 
     const message = this.buildMultiplexedMessage(stream, payload);
-    const unsubscribeMessage = this.buildMultiplexedMessage(stream, payload);
+    const unsubscribeMessage = this.buildMultiplexedMessage(stream, unsubscribePayload);
     const createListenerId = options.create ? this.dispatcher.listen(createSelector, handler) : null;
     const updateListenerId = this.dispatcher.listen(updateSelector, handler);
     const deleteListenerId = this.dispatcher.listen(deleteSelector, handler);

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -162,7 +162,7 @@ interface ICancelable {
   /**
    * @return true if canceled, false if already canceled.
    */
-  cancel(): boolean;
+  cancel(): Promise<boolean>;
 }
 
 
@@ -469,6 +469,7 @@ export type SubscribeDeleteSelectorBuilder = (stream: string, requestId: string)
  * @param requestId The request ID to use in the subscription request
  */
 export type SubscribePayloadBuilder = (action: string, args: object, requestId: string) => object;
+export type UnsubscribePayloadBuilder = (action: string, args: object, requestId: string) => object;
 
 
 export
@@ -490,6 +491,7 @@ interface IDCRFOptions {
   buildSubscribeUpdateSelector?: SubscribeUpdateSelectorBuilder,
   buildSubscribeDeleteSelector?: SubscribeDeleteSelectorBuilder,
   buildSubscribePayload?: SubscribePayloadBuilder,
+  buildUnsubscribePayload?: UnsubscribePayloadBuilder,
 
   // ReconnectingWebsocket options
   websocket?: ReconnectingWebsocketOptions

--- a/src/subscriptions.ts
+++ b/src/subscriptions.ts
@@ -6,12 +6,10 @@
  */
 export
 class SubscriptionPromise<T> extends Promise<T> {
-  protected unsubscribe: () => boolean;
+  protected unsubscribe: () => Promise<boolean>;
 
-  constructor(executor: (resolve: (value?: T | PromiseLike<T>) => void,
-                         reject: (reason?: any) => void
-                        ) => void,
-              unsubscribe: () => boolean) {
+  constructor(executor: (resolve: (value?: (PromiseLike<T> | T)) => void, reject: (reason?: any) => void) => void,
+                unsubscribe: () => Promise<boolean>) {
     super(executor);
     this.unsubscribe = unsubscribe;
   }
@@ -20,7 +18,7 @@ class SubscriptionPromise<T> extends Promise<T> {
    * Stop listening for new events on this subscription
    * @return true if the subscription was active, false if it was already unsubscribed
    */
-  public cancel(): boolean {
-    return this.unsubscribe();
+  public async cancel(): Promise<boolean> {
+    return await this.unsubscribe();
   }
 }


### PR DESCRIPTION
This pull request makes the following changes:

- Change `subscribe` method to allow use in handling custom subscription actions, such as subscribing to django models via a filter. Specifically, allow action names to be customized and create events to be listened for. This change allows the following code example to function.
  ```javascript
  import dcrf from "dcrf-client";
  
  const visit = {
      id: 5,
      // ...
  };
  let exams = [];
  let related_exams_subscription = null;
  const dcrfClient = dcrf.connect(`ws://${window.location.host}/api/`, {
      pkField: "id",
  });
  dcrfClient.list("exam", { visit: this.visit.id })
      .then(async listedExams => {
          exams = listedExams;
          related_exams_subscription = this.dcrfClient.subscribe(
              "exam",
              {
                  visit_pk: visit.id,
              },
              this.handleExamSubscription,
              {
                  create: true,
                  subscribeAction: "subscribe_to_exams_on_visit",
                  unsubscribeAction: "unsubscribe_to_exams_on_visit",
              }
          );
      });
  ```
- Prevent duplicate resubscription messages from being sent, previous code sends a resubscription for every listener, but there are multiple listeners per subscription.
- Implement unsubscribe messages being sent on `SubscribePromise.cancel` and `unsubscribeAll`. (Changes `SubscribePromise.cancel` to be async.)

This pull request is not in a finished state right now, with regards to tests. I haven't been able to run the integration tests re: https://github.com/theY4Kman/dcrf-client/issues/10. I'd also like to get your input on what unit tests should be added for this functionality.