### PR TITLE
Custom subscription actions

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ verify_ssl = true
 
 [dev-packages]
 pytest = "~=6.2.1"
-pytest-django = "~=3.4.8"
+pytest-django = "~=4.3.0"
 pytest-pythonpath = "~=0.7.3"
 
 [packages]

--- a/Pipfile
+++ b/Pipfile
@@ -4,15 +4,15 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
-pytest = "*"
-pytest-django = "*"
-pytest-pythonpath = "*"
+pytest = "~=6.2.1"
+pytest-django = "~=3.4.8"
+pytest-pythonpath = "~=0.7.3"
 
 [packages]
-djangochannelsrestframework = "*"
-channelsmultiplexer = "*"
-testing-redis = "*"
-channels-redis = "*"
+djangochannelsrestframework = "~=0.2.1"
+channelsmultiplexer = "~=0.0.3"
+testing-redis = "~=1.1.1"
+channels-redis = "~=3.2.0"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile
+++ b/Pipfile
@@ -15,4 +15,4 @@ testing-redis = "~=1.1.1"
 channels-redis = "~=3.2.0"
 
 [requires]
-python_version = "3.7"
+python_version = "3.8"

--- a/Pipfile
+++ b/Pipfile
@@ -9,8 +9,8 @@ pytest-django = "~=3.4.8"
 pytest-pythonpath = "~=0.7.3"
 
 [packages]
-djangochannelsrestframework = "~=0.2.1"
-channelsmultiplexer = "~=0.0.3"
+djangochannelsrestframework = "==0.2.2"
+channelsmultiplexer = "==0.0.3"
 testing-redis = "~=1.1.1"
 channels-redis = "~=3.2.0"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5dd547bbed2fd75fe0c6afc289cce7fe615f3feeaa711941602e353565778722"
+            "sha256": "a3b32ae8e1465d0958af9e8e3afd0b56f69649494d145633c1e1a5ab3814f26c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -49,11 +49,11 @@
         },
         "autobahn": {
             "hashes": [
-                "sha256:24ce276d313e84d68241c3aef30d484f352b90a40168981b3640312c821df77b",
-                "sha256:86bbce30cdd407137c57670993a8f9bfdfe3f8e994b889181d85e844d5aa8dfb"
+                "sha256:410a93e0e29882c8b5d5ab05d220b07609b886ef5f23c0b8d39153254ffd6895",
+                "sha256:52ee4236ff9a1fcbbd9500439dcf3284284b37f8a6b31ecc8a36e00cf9f95049"
             ],
-            "markers": "python_version >= '3.5'",
-            "version": "==20.7.1"
+            "markers": "python_version >= '3.6'",
+            "version": "==20.12.3"
         },
         "automat": {
             "hashes": [
@@ -105,11 +105,11 @@
         },
         "channels": {
             "hashes": [
-                "sha256:74db79c9eca616be69d38013b22083ab5d3f9ccda1ab5e69096b1bb7da2d9b18",
-                "sha256:f50a6e79757a64c1e45e95e144a2ac5f1e99ee44a0718ab182c501f5e5abd268"
+                "sha256:056b72e51080a517a0f33a0a30003e03833b551d75394d6636c885d4edb8188f",
+                "sha256:3f15bdd2138bb4796e76ea588a0a344b12a7964ea9b2e456f992fddb988a4317"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==3.0.2"
+            "version": "==3.0.3"
         },
         "channels-redis": {
             "hashes": [
@@ -135,31 +135,23 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:07ca431b788249af92764e3be9a488aa1d39a0bc3be313d826bbec690417e538",
-                "sha256:13b88a0bd044b4eae1ef40e265d006e34dbcde0c2f1e15eb9896501b2d8f6c6f",
-                "sha256:32434673d8505b42c0de4de86da8c1620651abd24afe91ae0335597683ed1b77",
-                "sha256:3cd75a683b15576cfc822c7c5742b3276e50b21a06672dc3a800a2d5da4ecd1b",
-                "sha256:4e7268a0ca14536fecfdf2b00297d4e407da904718658c1ff1961c713f90fd33",
-                "sha256:545a8550782dda68f8cdc75a6e3bf252017aa8f75f19f5a9ca940772fc0cb56e",
-                "sha256:55d0b896631412b6f0c7de56e12eb3e261ac347fbaa5d5e705291a9016e5f8cb",
-                "sha256:5849d59358547bf789ee7e0d7a9036b2d29e9a4ddf1ce5e06bb45634f995c53e",
-                "sha256:6dc59630ecce8c1f558277ceb212c751d6730bd12c80ea96b4ac65637c4f55e7",
-                "sha256:7117319b44ed1842c617d0a452383a5a052ec6aa726dfbaffa8b94c910444297",
-                "sha256:75e8e6684cf0034f6bf2a97095cb95f81537b12b36a8fedf06e73050bb171c2d",
-                "sha256:7b8d9d8d3a9bd240f453342981f765346c87ade811519f98664519696f8e6ab7",
-                "sha256:a035a10686532b0587d58a606004aa20ad895c60c4d029afa245802347fab57b",
-                "sha256:a4e27ed0b2504195f855b52052eadcc9795c59909c9d84314c5408687f933fc7",
-                "sha256:a733671100cd26d816eed39507e585c156e4498293a907029969234e5e634bc4",
-                "sha256:a75f306a16d9f9afebfbedc41c8c2351d8e61e818ba6b4c40815e2b5740bb6b8",
-                "sha256:bd717aa029217b8ef94a7d21632a3bb5a4e7218a4513d2521c2a2fd63011e98b",
-                "sha256:d25cecbac20713a7c3bc544372d42d8eafa89799f492a43b79e1dfd650484851",
-                "sha256:d26a2557d8f9122f9bf445fc7034242f4375bd4e95ecda007667540270965b13",
-                "sha256:d3545829ab42a66b84a9aaabf216a4dce7f16dbc76eb69be5c302ed6b8f4a29b",
-                "sha256:d3d5e10be0cf2a12214ddee45c6bd203dab435e3d83b4560c03066eda600bfe3",
-                "sha256:efe15aca4f64f3a7ea0c09c87826490e50ed166ce67368a68f315ea0807a20df"
+                "sha256:0003a52a123602e1acee177dc90dd201f9bb1e73f24a070db7d36c588e8f5c7d",
+                "sha256:0e85aaae861d0485eb5a79d33226dd6248d2a9f133b81532c8f5aae37de10ff7",
+                "sha256:594a1db4511bc4d960571536abe21b4e5c3003e8750ab8365fafce71c5d86901",
+                "sha256:69e836c9e5ff4373ce6d3ab311c1a2eed274793083858d3cd4c7d12ce20d5f9c",
+                "sha256:788a3c9942df5e4371c199d10383f44a105d67d401fb4304178020142f020244",
+                "sha256:7e177e4bea2de937a584b13645cab32f25e3d96fc0bc4a4cf99c27dc77682be6",
+                "sha256:83d9d2dfec70364a74f4e7c70ad04d3ca2e6a08b703606993407bf46b97868c5",
+                "sha256:84ef7a0c10c24a7773163f917f1cb6b4444597efd505a8aed0a22e8c4780f27e",
+                "sha256:9e21301f7a1e7c03dbea73e8602905a4ebba641547a462b26dd03451e5769e7c",
+                "sha256:9f6b0492d111b43de5f70052e24c1f0951cb9e6022188ebcb1cc3a3d301469b0",
+                "sha256:a69bd3c68b98298f490e84519b954335154917eaab52cf582fa2c5c7efc6e812",
+                "sha256:b4890d5fb9b7a23e3bf8abf5a8a7da8e228f1e97dc96b30b95685df840b6914a",
+                "sha256:c366df0401d1ec4e548bebe8f91d55ebcc0ec3137900d214dd7aac8427ef3030",
+                "sha256:dc42f645f8f3a489c3dd416730a514e7a91a59510ddaadc09d04224c098d3302"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==3.2.1"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==3.3.1"
         },
         "daphne": {
             "hashes": [
@@ -179,11 +171,10 @@
         },
         "djangochannelsrestframework": {
             "hashes": [
-                "sha256:55009e7e336b9324b07e127e519f96dab516c4037ecef0998234f9d74bd9dfd6",
-                "sha256:f9bbf6a6419633619fd99efcbfd12fdd2f9385540ad04d2dd95f8cc01af136a1"
+                "sha256:d5a6462f9912e16eaf8c86aadd8bd82af5d37fbfe18960d9329040fb8455b8c1"
             ],
             "index": "pypi",
-            "version": "==0.2.0"
+            "version": "==0.2.1"
         },
         "djangorestframework": {
             "hashes": [
@@ -268,26 +259,36 @@
         },
         "msgpack": {
             "hashes": [
-                "sha256:002a0d813e1f7b60da599bdf969e632074f9eec1b96cbed8fb0973a63160a408",
-                "sha256:25b3bc3190f3d9d965b818123b7752c5dfb953f0d774b454fd206c18fe384fb8",
-                "sha256:271b489499a43af001a2e42f42d876bb98ccaa7e20512ff37ca78c8e12e68f84",
-                "sha256:39c54fdebf5fa4dda733369012c59e7d085ebdfe35b6cf648f09d16708f1be5d",
-                "sha256:4233b7f86c1208190c78a525cd3828ca1623359ef48f78a6fea4b91bb995775a",
-                "sha256:5bea44181fc8e18eed1d0cd76e355073f00ce232ff9653a0ae88cb7d9e643322",
-                "sha256:5dba6d074fac9b24f29aaf1d2d032306c27f04187651511257e7831733293ec2",
-                "sha256:7a22c965588baeb07242cb561b63f309db27a07382825fc98aecaf0827c1538e",
-                "sha256:908944e3f038bca67fcfedb7845c4a257c7749bf9818632586b53bcf06ba4b97",
-                "sha256:9534d5cc480d4aff720233411a1f765be90885750b07df772380b34c10ecb5c0",
-                "sha256:aa5c057eab4f40ec47ea6f5a9825846be2ff6bf34102c560bad5cad5a677c5be",
-                "sha256:b3758dfd3423e358bbb18a7cccd1c74228dffa7a697e5be6cb9535de625c0dbf",
-                "sha256:c901e8058dd6653307906c5f157f26ed09eb94a850dddd989621098d347926ab",
-                "sha256:cec8bf10981ed70998d98431cd814db0ecf3384e6b113366e7f36af71a0fca08",
-                "sha256:db685187a415f51d6b937257474ca72199f393dad89534ebbdd7d7a3b000080e",
-                "sha256:e35b051077fc2f3ce12e7c6a34cf309680c63a842db3a0616ea6ed25ad20d272",
-                "sha256:e7bbdd8e2b277b77782f3ce34734b0dfde6cbe94ddb74de8d733d603c7f9e2b1",
-                "sha256:ea41c9219c597f1d2bf6b374d951d310d58684b5de9dc4bd2976db9e1e22c140"
+                "sha256:0cb94ee48675a45d3b86e61d13c1e6f1696f0183f0715544976356ff86f741d9",
+                "sha256:1026dcc10537d27dd2d26c327e552f05ce148977e9d7b9f1718748281b38c841",
+                "sha256:26a1759f1a88df5f1d0b393eb582ec022326994e311ba9c5818adc5374736439",
+                "sha256:2a5866bdc88d77f6e1370f82f2371c9bc6fc92fe898fa2dec0c5d4f5435a2694",
+                "sha256:31c17bbf2ae5e29e48d794c693b7ca7a0c73bd4280976d408c53df421e838d2a",
+                "sha256:497d2c12426adcd27ab83144057a705efb6acc7e85957a51d43cdcf7f258900f",
+                "sha256:5a9ee2540c78659a1dd0b110f73773533ee3108d4e1219b5a15a8d635b7aca0e",
+                "sha256:8521e5be9e3b93d4d5e07cb80b7e32353264d143c1f072309e1863174c6aadb1",
+                "sha256:87869ba567fe371c4555d2e11e4948778ab6b59d6cc9d8460d543e4cfbbddd1c",
+                "sha256:8ffb24a3b7518e843cd83538cf859e026d24ec41ac5721c18ed0c55101f9775b",
+                "sha256:92be4b12de4806d3c36810b0fe2aeedd8d493db39e2eb90742b9c09299eb5759",
+                "sha256:9ea52fff0473f9f3000987f313310208c879493491ef3ccf66268eff8d5a0326",
+                "sha256:a4355d2193106c7aa77c98fc955252a737d8550320ecdb2e9ac701e15e2943bc",
+                "sha256:a99b144475230982aee16b3d249170f1cccebf27fb0a08e9f603b69637a62192",
+                "sha256:ac25f3e0513f6673e8b405c3a80500eb7be1cf8f57584be524c4fa78fe8e0c83",
+                "sha256:b28c0876cce1466d7c2195d7658cf50e4730667196e2f1355c4209444717ee06",
+                "sha256:b55f7db883530b74c857e50e149126b91bb75d35c08b28db12dcb0346f15e46e",
+                "sha256:b6d9e2dae081aa35c44af9c4298de4ee72991305503442a5c74656d82b581fe9",
+                "sha256:c747c0cc08bd6d72a586310bda6ea72eeb28e7505990f342552315b229a19b33",
+                "sha256:d6c64601af8f3893d17ec233237030e3110f11b8a962cb66720bf70c0141aa54",
+                "sha256:d8167b84af26654c1124857d71650404336f4eb5cc06900667a493fc619ddd9f",
+                "sha256:de6bd7990a2c2dabe926b7e62a92886ccbf809425c347ae7de277067f97c2887",
+                "sha256:e36a812ef4705a291cdb4a2fd352f013134f26c6ff63477f20235138d1d21009",
+                "sha256:e89ec55871ed5473a041c0495b7b4e6099f6263438e0bd04ccd8418f92d5d7f2",
+                "sha256:f3e6aaf217ac1c7ce1563cf52a2f4f5d5b1f64e8729d794165db71da57257f0c",
+                "sha256:f484cd2dca68502de3704f056fa9b318c94b1539ed17a4c784266df5d6978c87",
+                "sha256:fae04496f5bc150eefad4e9571d1a76c55d021325dcd484ce45065ebbdd00984",
+                "sha256:fe07bc6735d08e492a327f496b7850e98cb4d112c56df69b0c844dbebcbb47f6"
             ],
-            "version": "==1.0.0"
+            "version": "==1.0.2"
         },
         "pyasn1": {
             "hashes": [
@@ -343,18 +344,18 @@
         },
         "pyopenssl": {
             "hashes": [
-                "sha256:898aefbde331ba718570244c3b01dcddb1b31a3b336613436a45e52e27d9a82d",
-                "sha256:92f08eccbd73701cf744e8ffd6989aa7842d48cbe3fea8a7c031c5647f590ac5"
+                "sha256:4c231c759543ba02560fcd2480c48dcec4dae34c9da7d3747c508227e0624b51",
+                "sha256:818ae18e06922c066f777a33f1fca45786d85edfe71cd043de6379337a7f274b"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==20.0.0"
+            "version": "==20.0.1"
         },
         "pytz": {
             "hashes": [
-                "sha256:3e6b7dd2d1e0a59084bcee14a17af60c5c562cdc16d828e8eba2e683d3a7e268",
-                "sha256:5c55e189b682d420be27c6995ba6edce0c0a77dd67bfbe2ae6607134d5851ffd"
+                "sha256:16962c5fb8db4a8f63a26646d8886e9d769b6c511543557bc84e9569fb9a9cb4",
+                "sha256:180befebb1927b16f6b57101720075a984c019ac16b1b7575673bea42c6c3da5"
             ],
-            "version": "==2020.4"
+            "version": "==2020.5"
         },
         "redis": {
             "hashes": [
@@ -436,11 +437,11 @@
         },
         "txaio": {
             "hashes": [
-                "sha256:17938f2bca4a9cabce61346758e482ca4e600160cbc28e861493eac74a19539d",
-                "sha256:38a469daf93c37e5527cb062653d6393ae11663147c42fab7ddc3f6d00d434ae"
+                "sha256:1488d31d564a116538cc1265ac3f7979fb6223bb5a9e9f1479436ee2c17d8549",
+                "sha256:a8676d6c68aea1f0e2548c4afdb8e6253873af3bc2659bb5bcd9f39dff7ff90f"
             ],
-            "markers": "python_version >= '3.5'",
-            "version": "==20.4.1"
+            "markers": "python_version >= '3.6'",
+            "version": "==20.12.1"
         },
         "zope.interface": {
             "hashes": [
@@ -519,11 +520,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:05af3bb85d320377db281cf254ab050e1a7ebcbf5410685a9a407e18a1f81236",
-                "sha256:eb41423378682dadb7166144a4926e443093863024de508ca5c9737d6bc08376"
+                "sha256:24e0da08660a87484d1602c30bb4902d74816b6985b93de36926f5bc95741858",
+                "sha256:78598185a7008a470d64526a8059de9aaa449238f280fc9eb6b13ba6c4109093"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==20.7"
+            "version": "==20.8"
         },
         "pluggy": {
             "hashes": [
@@ -535,11 +536,11 @@
         },
         "py": {
             "hashes": [
-                "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2",
-                "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"
+                "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3",
+                "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.9.0"
+            "version": "==1.10.0"
         },
         "pyparsing": {
             "hashes": [
@@ -551,19 +552,19 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:4288fed0d9153d9646bfcdf0c0428197dba1ecb27a33bb6e031d002fa88653fe",
-                "sha256:c0a7e94a8cdbc5422a51ccdad8e6f1024795939cc89159a0ae7f0b316ad3823e"
+                "sha256:1969f797a1a0dbd8ccf0fecc80262312729afea9c17f1d70ebf85c5e76c6f7c8",
+                "sha256:66e419b1899bc27346cb2c993e12c5e5e8daba9073c1fbce33b9807abc95c306"
             ],
             "index": "pypi",
-            "version": "==6.1.2"
+            "version": "==6.2.1"
         },
         "pytest-django": {
             "hashes": [
-                "sha256:10e384e6b8912ded92db64c58be8139d9ae23fb8361e5fc139d8e4f8fc601bc2",
-                "sha256:26f02c16d36fd4c8672390deebe3413678d89f30720c16efb8b2a6bf63b9041f"
+                "sha256:30d773f1768e8f214a3106f1090e00300ce6edfcac8c55fd13b675fe1cbd1c85",
+                "sha256:4d3283e774fe1d40630ee58bf34929b83875e4751b525eeb07a7506996eb42ee"
             ],
             "index": "pypi",
-            "version": "==4.1.0"
+            "version": "==3.4.8"
         },
         "pytest-pythonpath": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7f8fc940f5acdbefc106e3d9e6c82d61eb913c241af026a7653c50d7f90baeb7"
+            "sha256": "25a2d628579291c151297c92728f035fb4c7da20bf4659d05a2307e37e928eb7"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -538,11 +538,11 @@
         },
         "pytest-django": {
             "hashes": [
-                "sha256:30d773f1768e8f214a3106f1090e00300ce6edfcac8c55fd13b675fe1cbd1c85",
-                "sha256:4d3283e774fe1d40630ee58bf34929b83875e4751b525eeb07a7506996eb42ee"
+                "sha256:d1c6758a592fb0ef8abaa2fe12dd28858c1dcfc3d466102ffe52aa8934733dca",
+                "sha256:f96c4556f4e7b15d987dd1dcc1d1526df81d40c1548d31ce840d597ed2be8c46"
             ],
             "index": "pypi",
-            "version": "==3.4.8"
+            "version": "==4.3.0"
         },
         "pytest-pythonpath": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -25,11 +25,11 @@
         },
         "asgiref": {
             "hashes": [
-                "sha256:5ee950735509d04eb673bd7f7120f8fa1c9e2df495394992c73234d526907e17",
-                "sha256:7162a3cb30ab0609f1a4c95938fd73e8604f63bdba516a7f7d64b83ff09478f0"
+                "sha256:92906c611ce6c967347bbfea733f13d6313901d54dcca88195eaeb52b2a8e8ee",
+                "sha256:d1216dfbdfb63826470995d31caed36225dcaf34f182e0fa257a4dd9e86f1b78"
             ],
-            "markers": "python_version >= '3.5'",
-            "version": "==3.3.1"
+            "markers": "python_version >= '3.6'",
+            "version": "==3.3.4"
         },
         "async-timeout": {
             "hashes": [
@@ -41,19 +41,19 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6",
-                "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"
+                "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
+                "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==20.3.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==21.2.0"
         },
         "autobahn": {
             "hashes": [
-                "sha256:410a93e0e29882c8b5d5ab05d220b07609b886ef5f23c0b8d39153254ffd6895",
-                "sha256:52ee4236ff9a1fcbbd9500439dcf3284284b37f8a6b31ecc8a36e00cf9f95049"
+                "sha256:9195df8af03b0ff29ccd4b7f5abbde957ee90273465942205f9a1bad6c3f07ac",
+                "sha256:e126c1f583e872fb59e79d36977cfa1f2d0a8a79f90ae31f406faae7664b8e03"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==20.12.3"
+            "markers": "python_version >= '3.7'",
+            "version": "==21.3.1"
         },
         "automat": {
             "hashes": [
@@ -64,44 +64,57 @@
         },
         "cffi": {
             "hashes": [
-                "sha256:00a1ba5e2e95684448de9b89888ccd02c98d512064b4cb987d48f4b40aa0421e",
-                "sha256:00e28066507bfc3fe865a31f325c8391a1ac2916219340f87dfad602c3e48e5d",
-                "sha256:045d792900a75e8b1e1b0ab6787dd733a8190ffcf80e8c8ceb2fb10a29ff238a",
-                "sha256:0638c3ae1a0edfb77c6765d487fee624d2b1ee1bdfeffc1f0b58c64d149e7eec",
-                "sha256:105abaf8a6075dc96c1fe5ae7aae073f4696f2905fde6aeada4c9d2926752362",
-                "sha256:155136b51fd733fa94e1c2ea5211dcd4c8879869008fc811648f16541bf99668",
-                "sha256:1a465cbe98a7fd391d47dce4b8f7e5b921e6cd805ef421d04f5f66ba8f06086c",
-                "sha256:1d2c4994f515e5b485fd6d3a73d05526aa0fcf248eb135996b088d25dfa1865b",
-                "sha256:2c24d61263f511551f740d1a065eb0212db1dbbbbd241db758f5244281590c06",
-                "sha256:51a8b381b16ddd370178a65360ebe15fbc1c71cf6f584613a7ea08bfad946698",
-                "sha256:594234691ac0e9b770aee9fcdb8fa02c22e43e5c619456efd0d6c2bf276f3eb2",
-                "sha256:5cf4be6c304ad0b6602f5c4e90e2f59b47653ac1ed9c662ed379fe48a8f26b0c",
-                "sha256:64081b3f8f6f3c3de6191ec89d7dc6c86a8a43911f7ecb422c60e90c70be41c7",
-                "sha256:6bc25fc545a6b3d57b5f8618e59fc13d3a3a68431e8ca5fd4c13241cd70d0009",
-                "sha256:798caa2a2384b1cbe8a2a139d80734c9db54f9cc155c99d7cc92441a23871c03",
-                "sha256:7c6b1dece89874d9541fc974917b631406233ea0440d0bdfbb8e03bf39a49b3b",
-                "sha256:840793c68105fe031f34d6a086eaea153a0cd5c491cde82a74b420edd0a2b909",
-                "sha256:8d6603078baf4e11edc4168a514c5ce5b3ba6e3e9c374298cb88437957960a53",
-                "sha256:9cc46bc107224ff5b6d04369e7c595acb700c3613ad7bcf2e2012f62ece80c35",
-                "sha256:9f7a31251289b2ab6d4012f6e83e58bc3b96bd151f5b5262467f4bb6b34a7c26",
-                "sha256:9ffb888f19d54a4d4dfd4b3f29bc2c16aa4972f1c2ab9c4ab09b8ab8685b9c2b",
-                "sha256:a5ed8c05548b54b998b9498753fb9cadbfd92ee88e884641377d8a8b291bcc01",
-                "sha256:a7711edca4dcef1a75257b50a2fbfe92a65187c47dab5a0f1b9b332c5919a3fb",
-                "sha256:af5c59122a011049aad5dd87424b8e65a80e4a6477419c0c1015f73fb5ea0293",
-                "sha256:b18e0a9ef57d2b41f5c68beefa32317d286c3d6ac0484efd10d6e07491bb95dd",
-                "sha256:b4e248d1087abf9f4c10f3c398896c87ce82a9856494a7155823eb45a892395d",
-                "sha256:ba4e9e0ae13fc41c6b23299545e5ef73055213e466bd107953e4a013a5ddd7e3",
-                "sha256:c6332685306b6417a91b1ff9fae889b3ba65c2292d64bd9245c093b1b284809d",
-                "sha256:d5ff0621c88ce83a28a10d2ce719b2ee85635e85c515f12bac99a95306da4b2e",
-                "sha256:d9efd8b7a3ef378dd61a1e77367f1924375befc2eba06168b6ebfa903a5e59ca",
-                "sha256:df5169c4396adc04f9b0a05f13c074df878b6052430e03f50e68adf3a57aa28d",
-                "sha256:ebb253464a5d0482b191274f1c8bf00e33f7e0b9c66405fbffc61ed2c839c775",
-                "sha256:ec80dc47f54e6e9a78181ce05feb71a0353854cc26999db963695f950b5fb375",
-                "sha256:f032b34669220030f905152045dfa27741ce1a6db3324a5bc0b96b6c7420c87b",
-                "sha256:f60567825f791c6f8a592f3c6e3bd93dd2934e3f9dac189308426bd76b00ef3b",
-                "sha256:f803eaa94c2fcda012c047e62bc7a51b0bdabda1cad7a92a522694ea2d76e49f"
+                "sha256:005a36f41773e148deac64b08f233873a4d0c18b053d37da83f6af4d9087b813",
+                "sha256:04c468b622ed31d408fea2346bec5bbffba2cc44226302a0de1ade9f5ea3d373",
+                "sha256:06d7cd1abac2ffd92e65c0609661866709b4b2d82dd15f611e602b9b188b0b69",
+                "sha256:06db6321b7a68b2bd6df96d08a5adadc1fa0e8f419226e25b2a5fbf6ccc7350f",
+                "sha256:0857f0ae312d855239a55c81ef453ee8fd24136eaba8e87a2eceba644c0d4c06",
+                "sha256:0f861a89e0043afec2a51fd177a567005847973be86f709bbb044d7f42fc4e05",
+                "sha256:1071534bbbf8cbb31b498d5d9db0f274f2f7a865adca4ae429e147ba40f73dea",
+                "sha256:158d0d15119b4b7ff6b926536763dc0714313aa59e320ddf787502c70c4d4bee",
+                "sha256:1bf1ac1984eaa7675ca8d5745a8cb87ef7abecb5592178406e55858d411eadc0",
+                "sha256:1f436816fc868b098b0d63b8920de7d208c90a67212546d02f84fe78a9c26396",
+                "sha256:24a570cd11895b60829e941f2613a4f79df1a27344cbbb82164ef2e0116f09c7",
+                "sha256:24ec4ff2c5c0c8f9c6b87d5bb53555bf267e1e6f70e52e5a9740d32861d36b6f",
+                "sha256:2894f2df484ff56d717bead0a5c2abb6b9d2bf26d6960c4604d5c48bbc30ee73",
+                "sha256:29314480e958fd8aab22e4a58b355b629c59bf5f2ac2492b61e3dc06d8c7a315",
+                "sha256:293e7ea41280cb28c6fcaaa0b1aa1f533b8ce060b9e701d78511e1e6c4a1de76",
+                "sha256:34eff4b97f3d982fb93e2831e6750127d1355a923ebaeeb565407b3d2f8d41a1",
+                "sha256:35f27e6eb43380fa080dccf676dece30bef72e4a67617ffda586641cd4508d49",
+                "sha256:3c3f39fa737542161d8b0d680df2ec249334cd70a8f420f71c9304bd83c3cbed",
+                "sha256:3d3dd4c9e559eb172ecf00a2a7517e97d1e96de2a5e610bd9b68cea3925b4892",
+                "sha256:43e0b9d9e2c9e5d152946b9c5fe062c151614b262fda2e7b201204de0b99e482",
+                "sha256:48e1c69bbacfc3d932221851b39d49e81567a4d4aac3b21258d9c24578280058",
+                "sha256:51182f8927c5af975fece87b1b369f722c570fe169f9880764b1ee3bca8347b5",
+                "sha256:58e3f59d583d413809d60779492342801d6e82fefb89c86a38e040c16883be53",
+                "sha256:5de7970188bb46b7bf9858eb6890aad302577a5f6f75091fd7cdd3ef13ef3045",
+                "sha256:65fa59693c62cf06e45ddbb822165394a288edce9e276647f0046e1ec26920f3",
+                "sha256:681d07b0d1e3c462dd15585ef5e33cb021321588bebd910124ef4f4fb71aef55",
+                "sha256:69e395c24fc60aad6bb4fa7e583698ea6cc684648e1ffb7fe85e3c1ca131a7d5",
+                "sha256:6c97d7350133666fbb5cf4abdc1178c812cb205dc6f41d174a7b0f18fb93337e",
+                "sha256:6e4714cc64f474e4d6e37cfff31a814b509a35cb17de4fb1999907575684479c",
+                "sha256:72d8d3ef52c208ee1c7b2e341f7d71c6fd3157138abf1a95166e6165dd5d4369",
+                "sha256:8ae6299f6c68de06f136f1f9e69458eae58f1dacf10af5c17353eae03aa0d827",
+                "sha256:8b198cec6c72df5289c05b05b8b0969819783f9418e0409865dac47288d2a053",
+                "sha256:99cd03ae7988a93dd00bcd9d0b75e1f6c426063d6f03d2f90b89e29b25b82dfa",
+                "sha256:9cf8022fb8d07a97c178b02327b284521c7708d7c71a9c9c355c178ac4bbd3d4",
+                "sha256:9de2e279153a443c656f2defd67769e6d1e4163952b3c622dcea5b08a6405322",
+                "sha256:9e93e79c2551ff263400e1e4be085a1210e12073a31c2011dbbda14bda0c6132",
+                "sha256:9ff227395193126d82e60319a673a037d5de84633f11279e336f9c0f189ecc62",
+                "sha256:a465da611f6fa124963b91bf432d960a555563efe4ed1cc403ba5077b15370aa",
+                "sha256:ad17025d226ee5beec591b52800c11680fca3df50b8b29fe51d882576e039ee0",
+                "sha256:afb29c1ba2e5a3736f1c301d9d0abe3ec8b86957d04ddfa9d7a6a42b9367e396",
+                "sha256:b85eb46a81787c50650f2392b9b4ef23e1f126313b9e0e9013b35c15e4288e2e",
+                "sha256:bb89f306e5da99f4d922728ddcd6f7fcebb3241fc40edebcb7284d7514741991",
+                "sha256:cbde590d4faaa07c72bf979734738f328d239913ba3e043b1e98fe9a39f8b2b6",
+                "sha256:cc5a8e069b9ebfa22e26d0e6b97d6f9781302fe7f4f2b8776c3e1daea35f1adc",
+                "sha256:cd2868886d547469123fadc46eac7ea5253ea7fcb139f12e1dfc2bbd406427d1",
+                "sha256:d42b11d692e11b6634f7613ad8df5d6d5f8875f5d48939520d351007b3c13406",
+                "sha256:df5052c5d867c1ea0b311fb7c3cd28b19df469c056f7fdcfe88c7473aa63e333",
+                "sha256:f2d45f97ab6bb54753eab54fffe75aaf3de4ff2341c9daee1987ee1837636f1d",
+                "sha256:fd78e5fee591709f32ef6edb9a015b4aa1a5022598e36227500c8f4e02328d9c"
             ],
-            "version": "==1.14.4"
+            "version": "==1.14.5"
         },
         "channels": {
             "hashes": [
@@ -135,127 +148,122 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:0003a52a123602e1acee177dc90dd201f9bb1e73f24a070db7d36c588e8f5c7d",
-                "sha256:0e85aaae861d0485eb5a79d33226dd6248d2a9f133b81532c8f5aae37de10ff7",
-                "sha256:594a1db4511bc4d960571536abe21b4e5c3003e8750ab8365fafce71c5d86901",
-                "sha256:69e836c9e5ff4373ce6d3ab311c1a2eed274793083858d3cd4c7d12ce20d5f9c",
-                "sha256:788a3c9942df5e4371c199d10383f44a105d67d401fb4304178020142f020244",
-                "sha256:7e177e4bea2de937a584b13645cab32f25e3d96fc0bc4a4cf99c27dc77682be6",
-                "sha256:83d9d2dfec70364a74f4e7c70ad04d3ca2e6a08b703606993407bf46b97868c5",
-                "sha256:84ef7a0c10c24a7773163f917f1cb6b4444597efd505a8aed0a22e8c4780f27e",
-                "sha256:9e21301f7a1e7c03dbea73e8602905a4ebba641547a462b26dd03451e5769e7c",
-                "sha256:9f6b0492d111b43de5f70052e24c1f0951cb9e6022188ebcb1cc3a3d301469b0",
-                "sha256:a69bd3c68b98298f490e84519b954335154917eaab52cf582fa2c5c7efc6e812",
-                "sha256:b4890d5fb9b7a23e3bf8abf5a8a7da8e228f1e97dc96b30b95685df840b6914a",
-                "sha256:c366df0401d1ec4e548bebe8f91d55ebcc0ec3137900d214dd7aac8427ef3030",
-                "sha256:dc42f645f8f3a489c3dd416730a514e7a91a59510ddaadc09d04224c098d3302"
+                "sha256:0f1212a66329c80d68aeeb39b8a16d54ef57071bf22ff4e521657b27372e327d",
+                "sha256:1e056c28420c072c5e3cb36e2b23ee55e260cb04eee08f702e0edfec3fb51959",
+                "sha256:240f5c21aef0b73f40bb9f78d2caff73186700bf1bc6b94285699aff98cc16c6",
+                "sha256:26965837447f9c82f1855e0bc8bc4fb910240b6e0d16a664bb722df3b5b06873",
+                "sha256:37340614f8a5d2fb9aeea67fd159bfe4f5f4ed535b1090ce8ec428b2f15a11f2",
+                "sha256:3d10de8116d25649631977cb37da6cbdd2d6fa0e0281d014a5b7d337255ca713",
+                "sha256:3d8427734c781ea5f1b41d6589c293089704d4759e34597dce91014ac125aad1",
+                "sha256:7ec5d3b029f5fa2b179325908b9cd93db28ab7b85bb6c1db56b10e0b54235177",
+                "sha256:8e56e16617872b0957d1c9742a3f94b43533447fd78321514abbe7db216aa250",
+                "sha256:de4e5f7f68220d92b7637fc99847475b59154b7a1b3868fb7385337af54ac9ca",
+                "sha256:eb8cc2afe8b05acbd84a43905832ec78e7b3873fb124ca190f574dca7389a87d",
+                "sha256:ee77aa129f481be46f8d92a1a7db57269a2f23052d5f2433b4621bb457081cc9"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==3.3.1"
+            "markers": "python_version >= '3.6'",
+            "version": "==3.4.7"
         },
         "daphne": {
             "hashes": [
-                "sha256:0052c9887600c57054a5867d4b0240159fa009faa3bcf6a1627271d9cdcb005a",
-                "sha256:c22b692707f514de9013651ecb687f2abe4f35cf6fe292ece634e9f1737bc7e3"
+                "sha256:76ffae916ba3aa66b46996c14fa713e46004788167a4873d647544e750e0e99f",
+                "sha256:a9af943c79717bc52fe64a3c236ae5d3adccc8b5be19c881b442d2c3db233393"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==3.0.1"
+            "version": "==3.0.2"
         },
         "django": {
             "hashes": [
-                "sha256:5c866205f15e7a7123f1eec6ab939d22d5bde1416635cab259684af66d8e48a2",
-                "sha256:edb10b5c45e7e9c0fb1dc00b76ec7449aca258a39ffd613dbd078c51d19c9f03"
+                "sha256:13ac78dbfd189532cad8f383a27e58e18b3d33f80009ceb476d7fcbfc5dcebd8",
+                "sha256:7e0a1393d18c16b503663752a8b6790880c5084412618990ce8a81cc908b4962"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==3.1.4"
+            "version": "==3.2.3"
         },
         "djangochannelsrestframework": {
             "hashes": [
-                "sha256:d5a6462f9912e16eaf8c86aadd8bd82af5d37fbfe18960d9329040fb8455b8c1"
+                "sha256:8c38bfc1cb0cabb405bfb17b4c0dd36dc6bf34f8e4f0e9909ede0b67d03d1f8a",
+                "sha256:e774c1b087cd8f024a867ace05ec3be0e5efc1590a9ae5da1879a12d29ae3742"
             ],
             "index": "pypi",
-            "version": "==0.2.1"
+            "version": "==0.2.2"
         },
         "djangorestframework": {
             "hashes": [
-                "sha256:0209bafcb7b5010fdfec784034f059d512256424de2a0f084cb82b096d6dd6a7"
+                "sha256:6d1d59f623a5ad0509fe0d6bfe93cbdfe17b8116ebc8eda86d45f6e16e819aaf",
+                "sha256:f747949a8ddac876e879190df194b925c177cdeb725a099db1460872f7c0a7f2"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==3.12.2"
+            "version": "==3.12.4"
         },
         "hiredis": {
             "hashes": [
-                "sha256:06a039208f83744a702279b894c8cf24c14fd63c59cd917dcde168b79eef0680",
-                "sha256:0a909bf501459062aa1552be1461456518f367379fdc9fdb1f2ca5e4a1fdd7c0",
-                "sha256:18402d9e54fb278cb9a8c638df6f1550aca36a009d47ecf5aa263a38600f35b0",
-                "sha256:1e4cbbc3858ec7e680006e5ca590d89a5e083235988f26a004acf7244389ac01",
-                "sha256:23344e3c2177baf6975fbfa361ed92eb7d36d08f454636e5054b3faa7c2aff8a",
-                "sha256:289b31885b4996ce04cadfd5fc03d034dce8e2a8234479f7c9e23b9e245db06b",
-                "sha256:2c1c570ae7bf1bab304f29427e2475fe1856814312c4a1cf1cd0ee133f07a3c6",
-                "sha256:2c227c0ed371771ffda256034427320870e8ea2e4fd0c0a618c766e7c49aad73",
-                "sha256:3bb9b63d319402cead8bbd9dd55dca3b667d2997e9a0d8a1f9b6cc274db4baee",
-                "sha256:3ef2183de67b59930d2db8b8e8d4d58e00a50fcc5e92f4f678f6eed7a1c72d55",
-                "sha256:43b8ed3dbfd9171e44c554cb4acf4ee4505caa84c5e341858b50ea27dd2b6e12",
-                "sha256:47bcf3c5e6c1e87ceb86cdda2ee983fa0fe56a999e6185099b3c93a223f2fa9b",
-                "sha256:5263db1e2e1e8ae30500cdd75a979ff99dcc184201e6b4b820d0de74834d2323",
-                "sha256:5b1451727f02e7acbdf6aae4e06d75f66ee82966ff9114550381c3271a90f56c",
-                "sha256:6996883a8a6ff9117cbb3d6f5b0dcbbae6fb9e31e1a3e4e2f95e0214d9a1c655",
-                "sha256:6c96f64a54f030366657a54bb90b3093afc9c16c8e0dfa29fc0d6dbe169103a5",
-                "sha256:7332d5c3e35154cd234fd79573736ddcf7a0ade7a986db35b6196b9171493e75",
-                "sha256:7885b6f32c4a898e825bb7f56f36a02781ac4a951c63e4169f0afcf9c8c30dfb",
-                "sha256:7b0f63f10a166583ab744a58baad04e0f52cfea1ac27bfa1b0c21a48d1003c23",
-                "sha256:819f95d4eba3f9e484dd115ab7ab72845cf766b84286a00d4ecf76d33f1edca1",
-                "sha256:8968eeaa4d37a38f8ca1f9dbe53526b69628edc9c42229a5b2f56d98bb828c1f",
-                "sha256:89ebf69cb19a33d625db72d2ac589d26e936b8f7628531269accf4a3196e7872",
-                "sha256:8daecd778c1da45b8bd54fd41ffcd471a86beed3d8e57a43acf7a8d63bba4058",
-                "sha256:955ba8ea73cf3ed8bd2f963b4cb9f8f0dcb27becd2f4b3dd536fd24c45533454",
-                "sha256:964f18a59f5a64c0170f684c417f4fe3e695a536612e13074c4dd5d1c6d7c882",
-                "sha256:969843fbdfbf56cdb71da6f0bdf50f9985b8b8aeb630102945306cf10a9c6af2",
-                "sha256:996021ef33e0f50b97ff2d6b5f422a0fe5577de21a8873b58a779a5ddd1c3132",
-                "sha256:9e9c9078a7ce07e6fce366bd818be89365a35d2e4b163268f0ca9ba7e13bb2f6",
-                "sha256:a04901757cb0fb0f5602ac11dda48f5510f94372144d06c2563ba56c480b467c",
-                "sha256:a7bf1492429f18d205f3a818da3ff1f242f60aa59006e53dee00b4ef592a3363",
-                "sha256:aa0af2deb166a5e26e0d554b824605e660039b161e37ed4f01b8d04beec184f3",
-                "sha256:abfb15a6a7822f0fae681785cb38860e7a2cb1616a708d53df557b3d76c5bfd4",
-                "sha256:b253fe4df2afea4dfa6b1fa8c5fef212aff8bcaaeb4207e81eed05cb5e4a7919",
-                "sha256:b27f082f47d23cffc4cf1388b84fdc45c4ef6015f906cd7e0d988d9e35d36349",
-                "sha256:b33aea449e7f46738811fbc6f0b3177c6777a572207412bbbf6f525ffed001ae",
-                "sha256:b44f9421c4505c548435244d74037618f452844c5d3c67719d8a55e2613549da",
-                "sha256:bcc371151d1512201d0214c36c0c150b1dc64f19c2b1a8c9cb1d7c7c15ebd93f",
-                "sha256:c2851deeabd96d3f6283e9c6b26e0bfed4de2dc6fb15edf913e78b79fc5909ed",
-                "sha256:cdfd501c7ac5b198c15df800a3a34c38345f5182e5f80770caf362bccca65628",
-                "sha256:d2c0caffa47606d6d7c8af94ba42547bd2a441f06c74fd90a1ffe328524a6c64",
-                "sha256:dcb2db95e629962db5a355047fb8aefb012df6c8ae608930d391619dbd96fd86",
-                "sha256:e0eeb9c112fec2031927a1745788a181d0eecbacbed941fc5c4f7bc3f7b273bf",
-                "sha256:e154891263306200260d7f3051982774d7b9ef35af3509d5adbbe539afd2610c",
-                "sha256:e2e023a42dcbab8ed31f97c2bcdb980b7fbe0ada34037d87ba9d799664b58ded",
-                "sha256:e64be68255234bb489a574c4f2f8df7029c98c81ec4d160d6cd836e7f0679390",
-                "sha256:e82d6b930e02e80e5109b678c663a9ed210680ded81c1abaf54635d88d1da298"
+                "sha256:04026461eae67fdefa1949b7332e488224eac9e8f2b5c58c98b54d29af22093e",
+                "sha256:04927a4c651a0e9ec11c68e4427d917e44ff101f761cd3b5bc76f86aaa431d27",
+                "sha256:07bbf9bdcb82239f319b1f09e8ef4bdfaec50ed7d7ea51a56438f39193271163",
+                "sha256:09004096e953d7ebd508cded79f6b21e05dff5d7361771f59269425108e703bc",
+                "sha256:0adea425b764a08270820531ec2218d0508f8ae15a448568109ffcae050fee26",
+                "sha256:0b39ec237459922c6544d071cdcf92cbb5bc6685a30e7c6d985d8a3e3a75326e",
+                "sha256:0d5109337e1db373a892fdcf78eb145ffb6bbd66bb51989ec36117b9f7f9b579",
+                "sha256:0f41827028901814c709e744060843c77e78a3aca1e0d6875d2562372fcb405a",
+                "sha256:11d119507bb54e81f375e638225a2c057dda748f2b1deef05c2b1a5d42686048",
+                "sha256:1233e303645f468e399ec906b6b48ab7cd8391aae2d08daadbb5cad6ace4bd87",
+                "sha256:139705ce59d94eef2ceae9fd2ad58710b02aee91e7fa0ccb485665ca0ecbec63",
+                "sha256:1f03d4dadd595f7a69a75709bc81902673fa31964c75f93af74feac2f134cc54",
+                "sha256:240ce6dc19835971f38caf94b5738092cb1e641f8150a9ef9251b7825506cb05",
+                "sha256:294a6697dfa41a8cba4c365dd3715abc54d29a86a40ec6405d677ca853307cfb",
+                "sha256:3d55e36715ff06cdc0ab62f9591607c4324297b6b6ce5b58cb9928b3defe30ea",
+                "sha256:3dddf681284fe16d047d3ad37415b2e9ccdc6c8986c8062dbe51ab9a358b50a5",
+                "sha256:3f5f7e3a4ab824e3de1e1700f05ad76ee465f5f11f5db61c4b297ec29e692b2e",
+                "sha256:508999bec4422e646b05c95c598b64bdbef1edf0d2b715450a078ba21b385bcc",
+                "sha256:5d2a48c80cf5a338d58aae3c16872f4d452345e18350143b3bf7216d33ba7b99",
+                "sha256:5dc7a94bb11096bc4bffd41a3c4f2b958257085c01522aa81140c68b8bf1630a",
+                "sha256:65d653df249a2f95673976e4e9dd7ce10de61cfc6e64fa7eeaa6891a9559c581",
+                "sha256:7492af15f71f75ee93d2a618ca53fea8be85e7b625e323315169977fae752426",
+                "sha256:7f0055f1809b911ab347a25d786deff5e10e9cf083c3c3fd2dd04e8612e8d9db",
+                "sha256:807b3096205c7cec861c8803a6738e33ed86c9aae76cac0e19454245a6bbbc0a",
+                "sha256:81d6d8e39695f2c37954d1011c0480ef7cf444d4e3ae24bc5e89ee5de360139a",
+                "sha256:87c7c10d186f1743a8fd6a971ab6525d60abd5d5d200f31e073cd5e94d7e7a9d",
+                "sha256:8b42c0dc927b8d7c0eb59f97e6e34408e53bc489f9f90e66e568f329bff3e443",
+                "sha256:a00514362df15af041cc06e97aebabf2895e0a7c42c83c21894be12b84402d79",
+                "sha256:a39efc3ade8c1fb27c097fd112baf09d7fd70b8cb10ef1de4da6efbe066d381d",
+                "sha256:a4ee8000454ad4486fb9f28b0cab7fa1cd796fc36d639882d0b34109b5b3aec9",
+                "sha256:a7928283143a401e72a4fad43ecc85b35c27ae699cf5d54d39e1e72d97460e1d",
+                "sha256:adf4dd19d8875ac147bf926c727215a0faf21490b22c053db464e0bf0deb0485",
+                "sha256:ae8427a5e9062ba66fc2c62fb19a72276cf12c780e8db2b0956ea909c48acff5",
+                "sha256:b4c8b0bc5841e578d5fb32a16e0c305359b987b850a06964bd5a62739d688048",
+                "sha256:b84f29971f0ad4adaee391c6364e6f780d5aae7e9226d41964b26b49376071d0",
+                "sha256:c39c46d9e44447181cd502a35aad2bb178dbf1b1f86cf4db639d7b9614f837c6",
+                "sha256:cb2126603091902767d96bcb74093bd8b14982f41809f85c9b96e519c7e1dc41",
+                "sha256:dcef843f8de4e2ff5e35e96ec2a4abbdf403bd0f732ead127bd27e51f38ac298",
+                "sha256:e3447d9e074abf0e3cd85aef8131e01ab93f9f0e86654db7ac8a3f73c63706ce",
+                "sha256:f52010e0a44e3d8530437e7da38d11fb822acfb0d5b12e9cd5ba655509937ca0",
+                "sha256:f8196f739092a78e4f6b1b2172679ed3343c39c61a3e9d722ce6fcf1dac2824a"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.1.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==2.0.0"
         },
         "hyperlink": {
             "hashes": [
-                "sha256:47fcc7cd339c6cb2444463ec3277bdcfe142c8b1daf2160bdd52248deec815af",
-                "sha256:c528d405766f15a2c536230de7e160b65a08e20264d8891b3eb03307b0df3c63"
+                "sha256:427af957daa58bc909471c6c40f74c5450fa123dd093fc53efd2e91d2705a56b",
+                "sha256:e6b14c37ecb73e89c77d78cdb4c2cc8f3fb59a885c5b3f819ff4ed80f25af1b4"
             ],
-            "version": "==20.0.1"
+            "version": "==21.0.0"
         },
         "idna": {
             "hashes": [
-                "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
-                "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
+                "sha256:5205d03e7bcbb919cc9c19885f9920d622ca52448306f2377daede5cf3faac16",
+                "sha256:c5b02147e01ea9920e6b0a3f1f7bb833612d507592c837a6c49552768f4054e1"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.10"
+            "version": "==3.1"
         },
         "incremental": {
             "hashes": [
-                "sha256:717e12246dddf231a349175f48d74d93e2897244939173b01974ab6661406b9f",
-                "sha256:7b751696aaf36eebfab537e458929e194460051ccad279c72b755a167eebd4b3"
+                "sha256:02f5de5aff48f6b9f665d99d48bfc7ec03b6e3943210de7cfc88856d755d6f57",
+                "sha256:92014aebc6a20b78a8084cdd5645eeaa7f74b8933f70fa3ada2cfbd1e3b54321"
             ],
-            "version": "==17.5.0"
+            "version": "==21.3.0"
         },
         "msgpack": {
             "hashes": [
@@ -334,14 +342,6 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.20"
         },
-        "pyhamcrest": {
-            "hashes": [
-                "sha256:412e00137858f04bde0729913874a48485665f2d36fe9ee449f26be864af9316",
-                "sha256:7ead136e03655af85069b6f47b23eb7c3e5c221aa9f022a4fbb499f5b7308f29"
-            ],
-            "markers": "python_version >= '3.5'",
-            "version": "==2.0.2"
-        },
         "pyopenssl": {
             "hashes": [
                 "sha256:4c231c759543ba02560fcd2480c48dcec4dae34c9da7d3747c508227e0624b51",
@@ -352,10 +352,10 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:16962c5fb8db4a8f63a26646d8886e9d769b6c511543557bc84e9569fb9a9cb4",
-                "sha256:180befebb1927b16f6b57101720075a984c019ac16b1b7575673bea42c6c3da5"
+                "sha256:83a4a90894bf38e243cf052c8b58f381bfe9a7a483f6a9cab140bc7f702ac4da",
+                "sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798"
             ],
-            "version": "==2020.5"
+            "version": "==2021.1"
         },
         "redis": {
             "hashes": [
@@ -367,18 +367,18 @@
         },
         "service-identity": {
             "hashes": [
-                "sha256:001c0707759cb3de7e49c078a7c0c9cd12594161d3bf06b9c254fdcb1a60dc36",
-                "sha256:0858a54aabc5b459d1aafa8a518ed2081a285087f349fe3e55197989232e2e2d"
+                "sha256:6e6c6086ca271dc11b033d17c3a8bea9f24ebff920c587da090afc9519419d34",
+                "sha256:f0b0caac3d40627c3c04d7a51b6e06721857a0e10a8775f2d1d7e72901b3a7db"
             ],
-            "version": "==18.1.0"
+            "version": "==21.1.0"
         },
         "six": {
             "hashes": [
-                "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
-                "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.15.0"
+            "version": "==1.16.0"
         },
         "sqlparse": {
             "hashes": [
@@ -408,108 +408,86 @@
                 "tls"
             ],
             "hashes": [
-                "sha256:040eb6641125d2a9a09cf198ec7b83dd8858c6f51f6770325ed9959c00f5098f",
-                "sha256:147780b8caf21ba2aef3688628eaf13d7e7fe02a86747cd54bfaf2140538f042",
-                "sha256:158ddb80719a4813d292293ac44ba41d8b56555ed009d90994a278237ee63d2c",
-                "sha256:2182000d6ffc05d269e6c03bfcec8b57e20259ca1086180edaedec3f1e689292",
-                "sha256:25ffcf37944bdad4a99981bc74006d735a678d2b5c193781254fbbb6d69e3b22",
-                "sha256:3281d9ce889f7b21bdb73658e887141aa45a102baf3b2320eafcfba954fcefec",
-                "sha256:356e8d8dd3590e790e3dba4db139eb8a17aca64b46629c622e1b1597a4a92478",
-                "sha256:70952c56e4965b9f53b180daecf20a9595cf22b8d0935cd3bd664c90273c3ab2",
-                "sha256:7408c6635ee1b96587289283ebe90ee15dbf9614b05857b446055116bc822d29",
-                "sha256:7c547fd0215db9da8a1bc23182b309e84a232364cc26d829e9ee196ce840b114",
-                "sha256:894f6f3cfa57a15ea0d0714e4283913a5f2511dbd18653dd148eba53b3919797",
-                "sha256:94ac3d55a58c90e2075c5fe1853f2aa3892b73e3bf56395f743aefde8605eeaa",
-                "sha256:a58e61a2a01e5bcbe3b575c0099a2bcb8d70a75b1a087338e0c48dd6e01a5f15",
-                "sha256:c09c47ff9750a8e3aa60ad169c4b95006d455a29b80ad0901f031a103b2991cd",
-                "sha256:ca3a0b8c9110800e576d89b5337373e52018b41069bc879f12fa42b7eb2d0274",
-                "sha256:cd1dc5c85b58494138a3917752b54bb1daa0045d234b7c132c37a61d5483ebad",
-                "sha256:cdbc4c7f0cd7a2218b575844e970f05a1be1861c607b0e048c9bceca0c4d42f7",
-                "sha256:d267125cc0f1e8a0eed6319ba4ac7477da9b78a535601c49ecd20c875576433a",
-                "sha256:d72c55b5d56e176563b91d11952d13b01af8725c623e498db5507b6614fc1e10",
-                "sha256:d95803193561a243cb0401b0567c6b7987d3f2a67046770e1dccd1c9e49a9780",
-                "sha256:e92703bed0cc21d6cb5c61d66922b3b1564015ca8a51325bd164a5e33798d504",
-                "sha256:f058bd0168271de4dcdc39845b52dd0a4a2fecf5f1246335f13f5e96eaebb467",
-                "sha256:f3c19e5bd42bbe4bf345704ad7c326c74d3fd7a1b3844987853bef180be638d4"
+                "sha256:77544a8945cf69b98d2946689bbe0c75de7d145cdf11f391dd487eae8fc95a12",
+                "sha256:aab38085ea6cda5b378b519a0ec99986874921ee8881318626b0a3414bb2631e"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==20.3.0"
+            "markers": "python_full_version >= '3.5.4'",
+            "version": "==21.2.0"
         },
         "txaio": {
             "hashes": [
-                "sha256:1488d31d564a116538cc1265ac3f7979fb6223bb5a9e9f1479436ee2c17d8549",
-                "sha256:a8676d6c68aea1f0e2548c4afdb8e6253873af3bc2659bb5bcd9f39dff7ff90f"
+                "sha256:7d6f89745680233f1c4db9ddb748df5e88d2a7a37962be174c0fd04c8dba1dc8",
+                "sha256:c16b55f9a67b2419cfdf8846576e2ec9ba94fe6978a83080c352a80db31c93fb"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==20.12.1"
+            "version": "==21.2.1"
         },
         "zope.interface": {
             "hashes": [
-                "sha256:05a97ba92c1c7c26f25c9f671aa1ef85ffead6cdad13770e5b689cf983adc7e1",
-                "sha256:07d61722dd7d85547b7c6b0f5486b4338001fab349f2ac5cabc0b7182eb3425d",
-                "sha256:0a990dcc97806e5980bbb54b2e46b9cde9e48932d8e6984daf71ef1745516123",
-                "sha256:150e8bcb7253a34a4535aeea3de36c0bb3b1a6a47a183a95d65a194b3e07f232",
-                "sha256:1743bcfe45af8846b775086471c28258f4c6e9ee8ef37484de4495f15a98b549",
-                "sha256:1b5f6c8fff4ed32aa2dd43e84061bc8346f32d3ba6ad6e58f088fe109608f102",
-                "sha256:21e49123f375703cf824214939d39df0af62c47d122d955b2a8d9153ea08cfd5",
-                "sha256:21f579134a47083ffb5ddd1307f0405c91aa8b61ad4be6fd5af0171474fe0c45",
-                "sha256:27c267dc38a0f0079e96a2945ee65786d38ef111e413c702fbaaacbab6361d00",
-                "sha256:299bde0ab9e5c4a92f01a152b7fbabb460f31343f1416f9b7b983167ab1e33bc",
-                "sha256:2ab88d8f228f803fcb8cb7d222c579d13dab2d3622c51e8cf321280da01102a7",
-                "sha256:2ced4c35061eea623bc84c7711eedce8ecc3c2c51cd9c6afa6290df3bae9e104",
-                "sha256:2dcab01c660983ba5e5a612e0c935141ccbee67d2e2e14b833e01c2354bd8034",
-                "sha256:32546af61a9a9b141ca38d971aa6eb9800450fa6620ce6323cc30eec447861f3",
-                "sha256:32b40a4c46d199827d79c86bb8cb88b1bbb764f127876f2cb6f3a47f63dbada3",
-                "sha256:3cc94c69f6bd48ed86e8e24f358cb75095c8129827df1298518ab860115269a4",
-                "sha256:42b278ac0989d6f5cf58d7e0828ea6b5951464e3cf2ff229dd09a96cb6ba0c86",
-                "sha256:495b63fd0302f282ee6c1e6ea0f1c12cb3d1a49c8292d27287f01845ff252a96",
-                "sha256:4af87cdc0d4b14e600e6d3d09793dce3b7171348a094ba818e2a68ae7ee67546",
-                "sha256:4b94df9f2fdde7b9314321bab8448e6ad5a23b80542dcab53e329527d4099dcb",
-                "sha256:4c48ddb63e2b20fba4c6a2bf81b4d49e99b6d4587fb67a6cd33a2c1f003af3e3",
-                "sha256:4df9afd17bd5477e9f8c8b6bb8507e18dd0f8b4efe73bb99729ff203279e9e3b",
-                "sha256:518950fe6a5d56f94ba125107895f938a4f34f704c658986eae8255edb41163b",
-                "sha256:538298e4e113ccb8b41658d5a4b605bebe75e46a30ceca22a5a289cf02c80bec",
-                "sha256:55465121e72e208a7b69b53de791402affe6165083b2ea71b892728bd19ba9ae",
-                "sha256:588384d70a0f19b47409cfdb10e0c27c20e4293b74fc891df3d8eb47782b8b3e",
-                "sha256:6278c080d4afffc9016e14325f8734456831124e8c12caa754fd544435c08386",
-                "sha256:64ea6c221aeee4796860405e1aedec63424cda4202a7ad27a5066876db5b0fd2",
-                "sha256:681dbb33e2b40262b33fd383bae63c36d33fd79fa1a8e4092945430744ffd34a",
-                "sha256:6936aa9da390402d646a32a6a38d5409c2d2afb2950f045a7d02ab25a4e7d08d",
-                "sha256:778d0ec38bbd288b150a3ae363c8ffd88d2207a756842495e9bffd8a8afbc89a",
-                "sha256:8251f06a77985a2729a8bdbefbae79ee78567dddc3acbd499b87e705ca59fe24",
-                "sha256:83b4aa5344cce005a9cff5d0321b2e318e871cc1dfc793b66c32dd4f59e9770d",
-                "sha256:844fad925ac5c2ad4faaceb3b2520ad016b5280105c6e16e79838cf951903a7b",
-                "sha256:8ceb3667dd13b8133f2e4d637b5b00f240f066448e2aa89a41f4c2d78a26ce50",
-                "sha256:92dc0fb79675882d0b6138be4bf0cec7ea7c7eede60aaca78303d8e8dbdaa523",
-                "sha256:9789bd945e9f5bd026ed3f5b453d640befb8b1fc33a779c1fe8d3eb21fe3fb4a",
-                "sha256:a2b6d6eb693bc2fc6c484f2e5d93bd0b0da803fa77bf974f160533e555e4d095",
-                "sha256:aab9f1e34d810feb00bf841993552b8fcc6ae71d473c505381627143d0018a6a",
-                "sha256:abb61afd84f23099ac6099d804cdba9bd3b902aaaded3ffff47e490b0a495520",
-                "sha256:adf9ee115ae8ff8b6da4b854b4152f253b390ba64407a22d75456fe07dcbda65",
-                "sha256:aedc6c672b351afe6dfe17ff83ee5e7eb6ed44718f879a9328a68bdb20b57e11",
-                "sha256:b7a00ecb1434f8183395fac5366a21ee73d14900082ca37cf74993cf46baa56c",
-                "sha256:ba32f4a91c1cb7314c429b03afbf87b1fff4fb1c8db32260e7310104bd77f0c7",
-                "sha256:cbd0f2cbd8689861209cd89141371d3a22a11613304d1f0736492590aa0ab332",
-                "sha256:e4bc372b953bf6cec65a8d48482ba574f6e051621d157cf224227dbb55486b1e",
-                "sha256:eccac3d9aadc68e994b6d228cb0c8919fc47a5350d85a1b4d3d81d1e98baf40c",
-                "sha256:efd550b3da28195746bb43bd1d815058181a7ca6d9d6aa89dd37f5eefe2cacb7",
-                "sha256:efef581c8ba4d990770875e1a2218e856849d32ada2680e53aebc5d154a17e20",
-                "sha256:f057897711a630a0b7a6a03f1acf379b6ba25d37dc5dc217a97191984ba7f2fc",
-                "sha256:f37d45fab14ffef9d33a0dc3bc59ce0c5313e2253323312d47739192da94f5fd",
-                "sha256:f44906f70205d456d503105023041f1e63aece7623b31c390a0103db4de17537"
+                "sha256:08f9636e99a9d5410181ba0729e0408d3d8748026ea938f3b970a0249daa8192",
+                "sha256:0b465ae0962d49c68aa9733ba92a001b2a0933c317780435f00be7ecb959c702",
+                "sha256:0cba8477e300d64a11a9789ed40ee8932b59f9ee05f85276dbb4b59acee5dd09",
+                "sha256:0cee5187b60ed26d56eb2960136288ce91bcf61e2a9405660d271d1f122a69a4",
+                "sha256:0ea1d73b7c9dcbc5080bb8aaffb776f1c68e807767069b9ccdd06f27a161914a",
+                "sha256:0f91b5b948686659a8e28b728ff5e74b1be6bf40cb04704453617e5f1e945ef3",
+                "sha256:15e7d1f7a6ee16572e21e3576d2012b2778cbacf75eb4b7400be37455f5ca8bf",
+                "sha256:17776ecd3a1fdd2b2cd5373e5ef8b307162f581c693575ec62e7c5399d80794c",
+                "sha256:194d0bcb1374ac3e1e023961610dc8f2c78a0f5f634d0c737691e215569e640d",
+                "sha256:1c0e316c9add0db48a5b703833881351444398b04111188069a26a61cfb4df78",
+                "sha256:205e40ccde0f37496904572035deea747390a8b7dc65146d30b96e2dd1359a83",
+                "sha256:273f158fabc5ea33cbc936da0ab3d4ba80ede5351babc4f577d768e057651531",
+                "sha256:2876246527c91e101184f63ccd1d716ec9c46519cc5f3d5375a3351c46467c46",
+                "sha256:2c98384b254b37ce50eddd55db8d381a5c53b4c10ee66e1e7fe749824f894021",
+                "sha256:2e5a26f16503be6c826abca904e45f1a44ff275fdb7e9d1b75c10671c26f8b94",
+                "sha256:334701327f37c47fa628fc8b8d28c7d7730ce7daaf4bda1efb741679c2b087fc",
+                "sha256:3748fac0d0f6a304e674955ab1365d515993b3a0a865e16a11ec9d86fb307f63",
+                "sha256:3c02411a3b62668200910090a0dff17c0b25aaa36145082a5a6adf08fa281e54",
+                "sha256:3dd4952748521205697bc2802e4afac5ed4b02909bb799ba1fe239f77fd4e117",
+                "sha256:3f24df7124c323fceb53ff6168da70dbfbae1442b4f3da439cd441681f54fe25",
+                "sha256:469e2407e0fe9880ac690a3666f03eb4c3c444411a5a5fddfdabc5d184a79f05",
+                "sha256:4de4bc9b6d35c5af65b454d3e9bc98c50eb3960d5a3762c9438df57427134b8e",
+                "sha256:5208ebd5152e040640518a77827bdfcc73773a15a33d6644015b763b9c9febc1",
+                "sha256:52de7fc6c21b419078008f697fd4103dbc763288b1406b4562554bd47514c004",
+                "sha256:5bb3489b4558e49ad2c5118137cfeaf59434f9737fa9c5deefc72d22c23822e2",
+                "sha256:5dba5f530fec3f0988d83b78cc591b58c0b6eb8431a85edd1569a0539a8a5a0e",
+                "sha256:5dd9ca406499444f4c8299f803d4a14edf7890ecc595c8b1c7115c2342cadc5f",
+                "sha256:5f931a1c21dfa7a9c573ec1f50a31135ccce84e32507c54e1ea404894c5eb96f",
+                "sha256:63b82bb63de7c821428d513607e84c6d97d58afd1fe2eb645030bdc185440120",
+                "sha256:66c0061c91b3b9cf542131148ef7ecbecb2690d48d1612ec386de9d36766058f",
+                "sha256:6f0c02cbb9691b7c91d5009108f975f8ffeab5dff8f26d62e21c493060eff2a1",
+                "sha256:71aace0c42d53abe6fc7f726c5d3b60d90f3c5c055a447950ad6ea9cec2e37d9",
+                "sha256:7d97a4306898b05404a0dcdc32d9709b7d8832c0c542b861d9a826301719794e",
+                "sha256:7df1e1c05304f26faa49fa752a8c690126cf98b40b91d54e6e9cc3b7d6ffe8b7",
+                "sha256:8270252effc60b9642b423189a2fe90eb6b59e87cbee54549db3f5562ff8d1b8",
+                "sha256:867a5ad16892bf20e6c4ea2aab1971f45645ff3102ad29bd84c86027fa99997b",
+                "sha256:877473e675fdcc113c138813a5dd440da0769a2d81f4d86614e5d62b69497155",
+                "sha256:8892f89999ffd992208754851e5a052f6b5db70a1e3f7d54b17c5211e37a98c7",
+                "sha256:9a9845c4c6bb56e508651f005c4aeb0404e518c6f000d5a1123ab077ab769f5c",
+                "sha256:a1e6e96217a0f72e2b8629e271e1b280c6fa3fe6e59fa8f6701bec14e3354325",
+                "sha256:a8156e6a7f5e2a0ff0c5b21d6bcb45145efece1909efcbbbf48c56f8da68221d",
+                "sha256:a9506a7e80bcf6eacfff7f804c0ad5350c8c95b9010e4356a4b36f5322f09abb",
+                "sha256:af310ec8335016b5e52cae60cda4a4f2a60a788cbb949a4fbea13d441aa5a09e",
+                "sha256:b0297b1e05fd128d26cc2460c810d42e205d16d76799526dfa8c8ccd50e74959",
+                "sha256:bf68f4b2b6683e52bec69273562df15af352e5ed25d1b6641e7efddc5951d1a7",
+                "sha256:d0c1bc2fa9a7285719e5678584f6b92572a5b639d0e471bb8d4b650a1a910920",
+                "sha256:d4d9d6c1a455d4babd320203b918ccc7fcbefe308615c521062bc2ba1aa4d26e",
+                "sha256:db1fa631737dab9fa0b37f3979d8d2631e348c3b4e8325d6873c2541d0ae5a48",
+                "sha256:dd93ea5c0c7f3e25335ab7d22a507b1dc43976e1345508f845efc573d3d779d8",
+                "sha256:f44e517131a98f7a76696a7b21b164bcb85291cee106a23beccce454e1f433a4",
+                "sha256:f7ee479e96f7ee350db1cf24afa5685a5899e2b34992fb99e1f7c1b0b758d263"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==5.2.0"
+            "version": "==5.4.0"
         }
     },
     "develop": {
         "attrs": {
             "hashes": [
-                "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6",
-                "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"
+                "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
+                "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==20.3.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==21.2.0"
         },
         "iniconfig": {
             "hashes": [
@@ -520,11 +498,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:24e0da08660a87484d1602c30bb4902d74816b6985b93de36926f5bc95741858",
-                "sha256:78598185a7008a470d64526a8059de9aaa449238f280fc9eb6b13ba6c4109093"
+                "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5",
+                "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==20.8"
+            "version": "==20.9"
         },
         "pluggy": {
             "hashes": [
@@ -552,11 +530,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:1969f797a1a0dbd8ccf0fecc80262312729afea9c17f1d70ebf85c5e76c6f7c8",
-                "sha256:66e419b1899bc27346cb2c993e12c5e5e8daba9073c1fbce33b9807abc95c306"
+                "sha256:50bcad0a0b9c5a72c8e4e7c9855a3ad496ca6a881a3641b4260605450772c54b",
+                "sha256:91ef2131a9bd6be8f76f1f08eac5c5317221d6ad1e143ae03894b862e8976890"
             ],
             "index": "pypi",
-            "version": "==6.2.1"
+            "version": "==6.2.4"
         },
         "pytest-django": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a3b32ae8e1465d0958af9e8e3afd0b56f69649494d145633c1e1a5ab3814f26c"
+            "sha256": "7f8fc940f5acdbefc106e3d9e6c82d61eb913c241af026a7653c50d7f90baeb7"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -252,11 +252,11 @@
         },
         "idna": {
             "hashes": [
-                "sha256:5205d03e7bcbb919cc9c19885f9920d622ca52448306f2377daede5cf3faac16",
-                "sha256:c5b02147e01ea9920e6b0a3f1f7bb833612d507592c837a6c49552768f4054e1"
+                "sha256:14475042e284991034cb48e06f6851428fb14c4dc953acd9be9a5e95c7b6dd7a",
+                "sha256:467fbad99067910785144ce333826c71fb0e63a425657295239737f7ecd125f3"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==3.1"
+            "version": "==3.2"
         },
         "incremental": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "25a2d628579291c151297c92728f035fb4c7da20bf4659d05a2307e37e928eb7"
+            "sha256": "fdbb84adb0193278154f2f0fbc5df5142e589eccd954d170ab22adb11e49be4e"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.7"
+            "python_version": "3.8"
         },
         "sources": [
             {

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ To run both test suites: `npm run test`
 
 To run unit tests: `npm run test:unit` or `mocha`
 
-To run integration tests: `npm run test:integration` or `py.test`
+To run integration tests: `npm run test:integration` or `pipenv run py.test`
 
 
 ### How do the integration tests work?

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ There are two main test suites: unit tests (in `test/test.ts`) to verify intende
 
 Both suites utilize Mocha as the test runner, though the integration tests are executed through py.test, to provide a live server to make requests against.
 
-The integration tests require separate dependencies. To install them, first [install pipenv](https://pipenv.readthedocs.io/en/latest/install/#installing-pipenv), then run `pipenv install`.
+The integration tests require separate dependencies. To install them, first [install pipenv](https://pipenv.readthedocs.io/en/latest/install/#installing-pipenv), then run `pipenv install --dev`.
 
 To run both test suites: `npm run test`
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ const personalSubscription = client.subscribe('people', 1, (person, action) => {
     console.info('Person 1 was updated:', person);
   }
   else if (action === 'delete') {
-    console.info('Person 1 was deleted!')
+    console.info('Person 1 was deleted!');
   }
 });
 
@@ -68,6 +68,28 @@ personalSubscription.cancel();
 client.request('mystream', {key: 'value'}).then(response => {
   console.info('Got mystream response, yo:', response);
 });
+
+// Subscribe using a custom action
+const customSubscription = client.subscribe(
+  'people',
+  {},  // Additional arguments may be passed to action
+  (person, action) => {
+    if (action === 'create') {
+      console.info(`Person ${person.pk} was created:`, person);
+    }
+    else if (action === 'update') {
+      console.info(`Person ${person.pk} was updated:`, person);
+    }
+    else if (action === 'delete') {
+      console.info(`Person ${person.pk} was deleted!`);
+    }
+  },
+  {
+    includeCreateEvents: true,
+    subscribeAction: 'subscribe_all',
+    unsubscribeAction: 'unsubscribe_all',
+  },
+);
 ```
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -288,8 +288,7 @@
     "@types/lodash": {
       "version": "4.14.123",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.123.tgz",
-      "integrity": "sha512-pQvPkc4Nltyx7G1Ww45OjVqUsJP4UsZm+GWJpigXgkikZqJgRm4c48g027o6tdgubWHwFRF15iFd+Y4Pmqv6+Q==",
-      "dev": true
+      "integrity": "sha512-pQvPkc4Nltyx7G1Ww45OjVqUsJP4UsZm+GWJpigXgkikZqJgRm4c48g027o6tdgubWHwFRF15iFd+Y4Pmqv6+Q=="
     },
     "@types/lodash.ismatch": {
       "version": "4.4.6",
@@ -305,6 +304,14 @@
       "resolved": "https://registry.npmjs.org/@types/lodash.pull/-/lodash.pull-4.1.6.tgz",
       "integrity": "sha512-pK+efqDL+Of68Gqd81LfOdBAmB5X6+SHM6kkUTTFQWqOPAomn3BWJcASLrr998SRE7aYLnDVmM5wLLbS7T159A==",
       "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
+    "@types/lodash.uniqby": {
+      "version": "4.7.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash.uniqby/-/lodash.uniqby-4.7.6.tgz",
+      "integrity": "sha512-9wBhrm1y6asW50Joj6tsySCNUgzK2tCqL7vtKIej0E9RyeBFdcte7fxUosmFuMoOU0eHqOMK76kCCrK99jxHgg==",
       "requires": {
         "@types/lodash": "*"
       }
@@ -1196,6 +1203,11 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/lodash.pull/-/lodash.pull-4.1.0.tgz",
       "integrity": "sha1-YAYMxr1iW01FZ+wn3EXNG+nuwBI="
+    },
+    "lodash.uniqby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+      "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI="
     },
     "log-symbols": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dcrf-client",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -212,6 +212,16 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@dabh/diagnostics": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.2.tgz",
+      "integrity": "sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==",
+      "requires": {
+        "colorspace": "1.1.x",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.4.0.tgz",
@@ -298,12 +308,6 @@
       "requires": {
         "@types/lodash": "*"
       }
-    },
-    "@types/loglevel": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@types/loglevel/-/loglevel-1.5.4.tgz",
-      "integrity": "sha512-8dx4ckP0vndJeN+iKZwdGiapLqFjVQ3JLOt92uqK0C63acs5NcPLbUOpfXCJkKVRjZLBQjw8NIGNBSsnatFnFQ==",
-      "dev": true
     },
     "@types/mocha": {
       "version": "5.2.6",
@@ -403,6 +407,11 @@
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
+    },
+    "async": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
     },
     "async-limiter": {
       "version": "1.0.0",
@@ -734,11 +743,19 @@
         }
       }
     },
+    "color": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
+      "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
+      "requires": {
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -746,8 +763,30 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "color-string": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.4.tgz",
+      "integrity": "sha512-57yF5yt8Xa3czSEW1jfQDE79Idk0+AkN/4KWad6tbdxUmAs3MvjxlWSWD4deYytcRfoZ9nhKyFl1kj5tBvidbw==",
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
+    },
+    "colorspace": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
+      "integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
+      "requires": {
+        "color": "3.0.x",
+        "text-hex": "1.0.x"
+      }
     },
     "commander": {
       "version": "2.19.0",
@@ -781,6 +820,11 @@
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
       "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
       "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "deasync": {
       "version": "0.1.14",
@@ -836,6 +880,11 @@
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
     },
+    "enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -853,6 +902,16 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
+    },
+    "fast-safe-stringify": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
+    },
+    "fecha": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.0.tgz",
+      "integrity": "sha512-aN3pcx/DSmtyoovUudctc8+6Hl4T+hI9GBBHLjA76jdZl7+b1sgh5g4k+u/GL3dTy1/pnYzKp69FpJ0OicE3Wg=="
     },
     "fill-range": {
       "version": "7.0.1",
@@ -888,6 +947,11 @@
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
       "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
       "dev": true
+    },
+    "fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -983,8 +1047,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "invariant": {
       "version": "2.2.4",
@@ -994,6 +1057,11 @@
       "requires": {
         "loose-envify": "^1.0.0"
       }
+    },
+    "is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
     },
     "is-binary-path": {
       "version": "2.1.0",
@@ -1036,6 +1104,16 @@
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
       "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
       "dev": true
+    },
+    "is-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -1087,6 +1165,11 @@
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
       "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
       "dev": true
+    },
+    "kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
     },
     "locate-path": {
       "version": "3.0.0",
@@ -1174,10 +1257,17 @@
         }
       }
     },
-    "loglevel": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.1.tgz",
-      "integrity": "sha1-4PyVEztu8nbNyIh82vJKpvFW+Po="
+    "logform": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.2.0.tgz",
+      "integrity": "sha512-N0qPlqfypFx7UHNn4B3lzS/b0uLqt2hmuoa+PpuXNYgozdJYAyauF5Ky0BWVjrxDlMWiT3qN4zPq3vVAfZy7Yg==",
+      "requires": {
+        "colors": "^1.2.1",
+        "fast-safe-stringify": "^2.0.4",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "triple-beam": "^1.3.0"
+      }
     },
     "lolex": {
       "version": "3.1.0",
@@ -1362,8 +1452,7 @@
     "ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-      "dev": true
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "nanoid": {
       "version": "3.1.12",
@@ -1417,6 +1506,14 @@
       "dev": true,
       "requires": {
         "wrappy": "1"
+      }
+    },
+    "one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "requires": {
+        "fn.name": "1.x.x"
       }
     },
     "p-limit": {
@@ -1514,6 +1611,11 @@
         "find-up": "^3.0.0"
       }
     },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -1521,6 +1623,16 @@
       "dev": true,
       "requires": {
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
       }
     },
     "readdirp": {
@@ -1567,8 +1679,7 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "semver": {
       "version": "5.6.0",
@@ -1590,6 +1701,14 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
+    },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      }
     },
     "sinon": {
       "version": "7.3.1",
@@ -1653,6 +1772,11 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -1680,6 +1804,21 @@
         }
       }
     },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        }
+      }
+    },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -1701,6 +1840,11 @@
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
     },
+    "text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+    },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -1721,6 +1865,11 @@
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
+    },
+    "triple-beam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+      "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
     "ts-node": {
       "version": "8.0.3",
@@ -1783,6 +1932,11 @@
       "integrity": "sha512-jjOcCZvpkl2+z7JFn0yBOoLQyLoIkNZAs/fYJkUG6VKy6zLPHJGfQJYFHzibB6GJaF/8QrcECtlQ5cpvRHSMEA==",
       "dev": true
     },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
     "which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -1805,6 +1959,55 @@
       "dev": true,
       "requires": {
         "string-width": "^1.0.2 || 2"
+      }
+    },
+    "winston": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.3.3.tgz",
+      "integrity": "sha512-oEXTISQnC8VlSAKf1KYSSd7J6IWuRPQqDdo8eoRNaYKLvwSb5+79Z3Yi1lrl6KDpU6/VWaxpakDAtb1oQ4n9aw==",
+      "requires": {
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.1.0",
+        "is-stream": "^2.0.0",
+        "logform": "^2.2.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.4.0"
+      }
+    },
+    "winston-transport": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.0.tgz",
+      "integrity": "sha512-Lc7/p3GtqtqPBYYtS6KCN3c77/2QCev51DvcJKbkFPQNoj1sinkGwLGFDxkXY9J6p9+EPnYs+D90uwbnaiURTw==",
+      "requires": {
+        "readable-stream": "^2.3.7",
+        "triple-beam": "^1.2.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "workerpool": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1939,9 +1939,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.3.4000",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.4000.tgz",
-      "integrity": "sha512-jjOcCZvpkl2+z7JFn0yBOoLQyLoIkNZAs/fYJkUG6VKy6zLPHJGfQJYFHzibB6GJaF/8QrcECtlQ5cpvRHSMEA==",
+      "version": "3.9.9",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
+      "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
       "dev": true
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@types/deasync": "^0.1.0",
     "@types/lodash.ismatch": "^4.4.6",
     "@types/lodash.pull": "^4.1.6",
-    "@types/loglevel": "^1.5.4",
     "@types/mocha": "^5.2.6",
     "@types/node": "^11.11.4",
     "@types/sinon": "^7.0.10",
@@ -63,7 +62,7 @@
     "autobind-decorator": "^2.4.0",
     "lodash.ismatch": "^4.4.0",
     "lodash.pull": "^4.1.0",
-    "loglevel": "^1.6.1",
-    "reconnecting-websocket": "^4.4.0"
+    "reconnecting-websocket": "^4.4.0",
+    "winston": "^3.3.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,10 +59,12 @@
     "ws": "^6.2.0"
   },
   "dependencies": {
+    "@types/lodash.uniqby": "^4.7.6",
     "autobind-decorator": "^2.4.0",
     "lodash.ismatch": "^4.4.0",
     "lodash.pull": "^4.1.0",
     "reconnecting-websocket": "^4.4.0",
+    "lodash.uniqby": "^4.7.0",
     "winston": "^3.3.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "prepare": "npm run build",
     "test": "npm run test:unit; npm run test:integration",
     "test:unit": "mocha",
-    "test:integration": "py.test || true"
+    "test:integration": "pipenv run py.test || true"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "sinon-chai": "^3.3.0",
     "ts-node": "^8.0.3",
     "tslint": "^5.14.0",
-    "typescript": "^3.3.4000",
+    "typescript": "^3.7.7",
     "ws": "^6.2.0"
   },
   "dependencies": {

--- a/pytest.ini
+++ b/pytest.ini
@@ -10,3 +10,6 @@ python_paths = ./test/integration
 DJANGO_SETTINGS_MODULE = dcrf_client_test.settings
 
 python_files = test.py
+
+filterwarnings =
+    ignore:the imp module is deprecated in favour of importlib.*:DeprecationWarning

--- a/src/dispatchers/fifo.ts
+++ b/src/dispatchers/fifo.ts
@@ -1,7 +1,10 @@
 import isMatch from 'lodash.ismatch';
 import pull from 'lodash.pull';
 
+import { getLogger } from '../logging';
 import {DispatchListener, IDispatcher} from '../interface';
+
+const log = getLogger('dcrf.dispatchers.fifo');
 
 
 type Listener<S, P extends S> = {
@@ -60,8 +63,13 @@ class FifoDispatcher implements IDispatcher {
     let matches = 0;
     listeners.forEach(({selector, handler}) => {
       if (isMatch(payload, selector)) {
+        log.debug('Matched selector %o with payload %o. Invoking handler %s',
+                  selector, payload, handler.name);
         matches++;
         handler(payload);
+      } else {
+        log.silly('Unable to match selector %o with payload %o. Not invoking handler %s',
+                  selector, payload, handler.name);
       }
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import JSONSerializer from './serializers/json';
 
 import {SubscriptionPromise} from './subscriptions';
 import WebsocketTransport from './transports/websocket';
+import {uniqBy} from "lodash";
 
 
 const log = getLogger('dcrf');
@@ -233,11 +234,15 @@ class DCRFClient implements IStreamingAPI {
    * Send subscription requests for all registered subscriptions
    */
   public resubscribe() {
-    const subscriptions: Array<{message: object}> = Object.values(this.subscriptions);
+    const subscriptions: Array<ISubscriptionDescriptor<any, any>> = Object.values(this.subscriptions);
+    const resubscribeMessages = uniqBy(subscriptions, (s) => {
+      // @ts-ignore
+      return s.message.payload.request_id
+    })
 
     log.info('Resending %d subscription requests', subscriptions.length);
 
-    for (const {message} of subscriptions) {
+    for (const {message} of resubscribeMessages) {
       this.sendNow(message);
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -221,7 +221,7 @@ class DCRFClient implements IStreamingAPI {
     const unsubscribe = async () => {
       const create = createListenerId ? this.unsubscribe(createListenerId) : false;
       const subbed = create || this.unsubscribe(updateListenerId) || this.unsubscribe(deleteListenerId);
-      await this.request(stream, unsubscribeMessage, requestId)
+      await this.request(stream, unsubscribePayload, requestId)
       return subbed;
     };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {
   IStreamingAPI,
   ITransport,
   SubscriptionHandler,
+  SubscribeOptions,
 } from './interface';
 
 import UUID from './lib/UUID';
@@ -73,6 +74,8 @@ class DCRFClient implements IStreamingAPI {
       this.buildMultiplexedMessage = this.options.buildMultiplexedMessage.bind(this);
     if (this.options.buildRequestResponseSelector)
       this.buildRequestResponseSelector = this.options.buildRequestResponseSelector.bind(this);
+    if (this.options.buildSubscribeCreateSelector)
+      this.buildSubscribeCreateSelector = this.options.buildSubscribeCreateSelector.bind(this);
     if (this.options.buildSubscribeUpdateSelector)
       this.buildSubscribeUpdateSelector = this.options.buildSubscribeUpdateSelector.bind(this);
     if (this.options.buildSubscribeDeleteSelector)
@@ -147,36 +150,73 @@ class DCRFClient implements IStreamingAPI {
 
   public subscribe(
       stream: string,
-      pk: number,
+      args: object|number,
       callback: SubscriptionHandler,
-      requestId?: string,
+      options?: SubscribeOptions|string,
   ): SubscriptionPromise<object>
   {
     if (callback == null) {
       throw new Error('callback must be provided');
     }
 
-    if (requestId == null) {
-      requestId = UUID.generate();
+    if (typeof options === 'string') {
+      options = {
+        requestId: options
+      };
     }
 
-    const updateSelector = this.buildSubscribeUpdateSelector(stream, pk, requestId);
-    const deleteSelector = this.buildSubscribeDeleteSelector(stream, pk, requestId);
+    if (!options) {
+      options = {};
+    }
+
+    if (!options.create) {
+      options.create = false;
+    }
+
+    if (!options.requestId) {
+      options.requestId = UUID.generate();
+    }
+
+    if (!options.subscribeAction) {
+      options.subscribeAction = 'subscribe_instance';
+    }
+
+    if (!options.unsubscribeAction) {
+      options.unsubscribeAction = 'unsubscribe_instance';
+    }
+
+    if (args !== null && typeof args !== 'object') {
+        args = {
+          [options.subscribeAction === 'subscribe_instance' ? 'pk' : this.pkField]: args
+        };
+    }
+
+    const requestId = options.requestId;
+
+    const createSelector = this.buildSubscribeCreateSelector(stream, requestId);
+    const updateSelector = this.buildSubscribeUpdateSelector(stream, requestId);
+    const deleteSelector = this.buildSubscribeDeleteSelector(stream, requestId);
     const handler: (data: typeof updateSelector & {payload: {data: any, action: string}}) => void =
         this.buildSubscribeListener(callback);
-    const payload = this.buildSubscribePayload(pk, requestId);
+    const payload = this.buildSubscribePayload(options.subscribeAction, args, requestId);
 
     const message = this.buildMultiplexedMessage(stream, payload);
+    const createListenerId = options.create ? this.dispatcher.listen(createSelector, handler) : null;
     const updateListenerId = this.dispatcher.listen(updateSelector, handler);
     const deleteListenerId = this.dispatcher.listen(deleteSelector, handler);
 
-    this.subscriptions[updateListenerId] = {selector: updateSelector, handler, message};
+    if (createListenerId) {
+      this.subscriptions[createListenerId] = {selector: createSelector, handler, message, unsubscribeMessage};
+    }
+    this.subscriptions[updateListenerId] = {selector: updateSelector, handler, message, unsubscribeMessage};
+    this.subscriptions[deleteListenerId] = {selector: deleteSelector, handler, message, unsubscribeMessage};
 
     const requestPromise = this.request(stream, payload, requestId);
     const unsubscribe = () => {
-      this._unsubscribeUnsafe(deleteListenerId);
-      return this.unsubscribe(updateListenerId);
-    }
+      const create = createListenerId ? this.unsubscribe(createListenerId) : false;
+      const subbed = create || this.unsubscribe(updateListenerId) || this.unsubscribe(deleteListenerId);
+      return subbed;
+    };
 
     return new SubscriptionPromise((resolve, reject) => {
       requestPromise.then(resolve, reject);
@@ -297,34 +337,41 @@ class DCRFClient implements IStreamingAPI {
     };
   }
 
-  public buildSubscribeUpdateSelector(stream: string, pk: number, requestId: string): object {
+  public buildSubscribeCreateSelector(stream: string, requestId: string): object {
+    return {
+      stream,
+      payload: {
+        action: 'create',
+        request_id: requestId,
+      },
+    };
+  }
+
+  public buildSubscribeUpdateSelector(stream: string, requestId: string): object {
     return {
       stream,
       payload: {
         action: 'update',
-        data: {[this.pkField]: pk},
         request_id: requestId,
       },
     };
   }
 
-  public buildSubscribeDeleteSelector(stream: string, pk: number, requestId: string): object {
+  public buildSubscribeDeleteSelector(stream: string, requestId: string): object {
     return {
       stream,
       payload: {
         action: 'delete',
-        data: {pk},
         request_id: requestId,
       },
     };
   }
 
-  public buildSubscribePayload(pk: number, requestId: string): object {
+  public buildSubscribePayload(action: string, args: object, requestId: string): object {
     return {
-      action: 'subscribe_instance',
+      action,
       request_id: requestId,
-      pk,  // NOTE: the subscribe_instance action REQUIRES the literal argument `pk`.
-           //       this argument is NOT the same as the ID field of the model.
+      ...args,
     };
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ import JSONSerializer from './serializers/json';
 
 import {SubscriptionPromise} from './subscriptions';
 import WebsocketTransport from './transports/websocket';
-import {uniqBy} from "lodash";
+import uniqBy from "lodash.uniqby";
 
 
 const log = getLogger('dcrf');

--- a/src/index.ts
+++ b/src/index.ts
@@ -154,6 +154,12 @@ class DCRFClient implements IStreamingAPI {
     }, requestId);
   }
 
+  // Overloads
+  public subscribe(stream: string, pk: number, callback: SubscriptionHandler, options?: SubscribeOptions): SubscriptionPromise<object>;
+  public subscribe(stream: string, pk: number, callback: SubscriptionHandler, requestId?: string): SubscriptionPromise<object>;
+  public subscribe(stream: string, args: object, callback: SubscriptionHandler, options?: SubscribeOptions): SubscriptionPromise<object>;
+  public subscribe(stream: string, args: object, callback: SubscriptionHandler, requestId?: string): SubscriptionPromise<object>;
+
   public subscribe(
       stream: string,
       args: object | number,

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ interface ISubscriptionDescriptor<S, P extends S> {
   selector: S,
   handler: DispatchListener<P>,
   message: object,
+  unsubscribeMessage: object,
 }
 
 export
@@ -83,6 +84,8 @@ class DCRFClient implements IStreamingAPI {
       this.buildSubscribeDeleteSelector = this.options.buildSubscribeDeleteSelector.bind(this);
     if (this.options.buildSubscribePayload)
       this.buildSubscribePayload = this.options.buildSubscribePayload.bind(this);
+    if (this.options.buildUnsubscribePayload)
+      this.buildUnsubscribePayload = this.options.buildUnsubscribePayload.bind(this);
 
     this.queue.initialize(this.transport.send, this.transport.isConnected);
     this.subscriptions = {};
@@ -200,8 +203,10 @@ class DCRFClient implements IStreamingAPI {
     const handler: (data: typeof updateSelector & {payload: {data: any, action: string}}) => void =
         this.buildSubscribeListener(callback);
     const payload = this.buildSubscribePayload(options.subscribeAction, args, requestId);
+    const unsubscribePayload = this.buildUnsubscribePayload(options.unsubscribeAction, args, requestId);
 
     const message = this.buildMultiplexedMessage(stream, payload);
+    const unsubscribeMessage = this.buildMultiplexedMessage(stream, payload);
     const createListenerId = options.create ? this.dispatcher.listen(createSelector, handler) : null;
     const updateListenerId = this.dispatcher.listen(updateSelector, handler);
     const deleteListenerId = this.dispatcher.listen(deleteSelector, handler);
@@ -213,9 +218,10 @@ class DCRFClient implements IStreamingAPI {
     this.subscriptions[deleteListenerId] = {selector: deleteSelector, handler, message, unsubscribeMessage};
 
     const requestPromise = this.request(stream, payload, requestId);
-    const unsubscribe = () => {
+    const unsubscribe = async () => {
       const create = createListenerId ? this.unsubscribe(createListenerId) : false;
       const subbed = create || this.unsubscribe(updateListenerId) || this.unsubscribe(deleteListenerId);
+      await this.request(stream, unsubscribeMessage, requestId)
       return subbed;
     };
 
@@ -227,6 +233,20 @@ class DCRFClient implements IStreamingAPI {
   public unsubscribeAll(): number {
     const listenerIds = Object.keys(this.subscriptions).map(parseInt);
     listenerIds.forEach(listenerId => this._unsubscribeUnsafe(listenerId));
+
+    log.info('Removing %d listeners', listenerIds.length);
+
+    const subscriptions: Array<ISubscriptionDescriptor<any, any>> = Object.values(this.subscriptions);
+    const unsubscribeMessages = uniqBy(subscriptions, (s) => {
+      // @ts-ignore
+      return s.unsubscribeMessage.payload.request_id
+    });
+
+    log.info('Sending %d unsubscription requests', unsubscribeMessages.length);
+
+    for (const {unsubscribeMessage} of unsubscribeMessages) {
+      this.sendNow(unsubscribeMessage);
+    }
     return listenerIds.length;
   }
 
@@ -294,7 +314,6 @@ class DCRFClient implements IStreamingAPI {
 
   protected unsubscribe(listenerId: number): boolean {
     if (this.subscriptions.hasOwnProperty(listenerId)) {
-      // TODO: send unsubscription message (unsupported by channels-api at time of writing)
       this._unsubscribeUnsafe(listenerId);
       return true;
     } else {
@@ -373,6 +392,14 @@ class DCRFClient implements IStreamingAPI {
   }
 
   public buildSubscribePayload(action: string, args: object, requestId: string): object {
+    return {
+      action,
+      request_id: requestId,
+      ...args,
+    };
+  }
+
+  public buildUnsubscribePayload(action: string, args: object, requestId: string): object {
     return {
       action,
       request_id: requestId,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import autobind from 'autobind-decorator';
-import {getLogger} from 'loglevel';
+import {getLogger} from './logging';
 import FifoDispatcher from './dispatchers/fifo';
 
 import {
@@ -264,6 +264,7 @@ class DCRFClient implements IStreamingAPI {
 
   @autobind
   protected handleTransportMessage(event: IMessageEvent) {
+    log.debug('Received message over transport: %s', event.data);
     const data = this.serializer.deserialize(event.data);
     return this.handleMessage(data);
   }
@@ -274,7 +275,7 @@ class DCRFClient implements IStreamingAPI {
 
   @autobind
   protected handleTransportConnect() {
-    log.debug('Initial API connection over transport %s', this.transport);
+    log.debug('Initial API connection over transport %s', this.transport.constructor.name);
     this.queue.processQueue();
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -311,6 +311,7 @@ class DCRFClient implements IStreamingAPI {
     return send(bytes);
   }
 
+  @autobind
   protected unsubscribe(listenerId: number): boolean {
     if (this.subscriptions.hasOwnProperty(listenerId)) {
       this._unsubscribeUnsafe(listenerId);

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,12 +99,16 @@ class DCRFClient implements IStreamingAPI {
     this.transport.on('reconnect', this.handleTransportReconnect);
   }
 
-  public close(unsubscribe: boolean = true) {
+  public close(unsubscribe: boolean = true): Promise<any> {
+    let promise: Promise<any>;
+
     if (unsubscribe) {
-      this.unsubscribeAll();
+      promise = this.unsubscribeAll();
+    } else {
+      promise = Promise.resolve();
     }
 
-    this.transport.disconnect();
+    return promise.then(() => {this.transport.disconnect()});
   }
 
   public list(stream: string, data: object={}, requestId?: string): Promise<any> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -206,7 +206,7 @@ class DCRFClient implements IStreamingAPI {
     const unsubscribePayload = this.buildUnsubscribePayload(options.unsubscribeAction, args, requestId);
 
     const message = this.buildMultiplexedMessage(stream, payload);
-    const unsubscribeMessage = this.buildMultiplexedMessage(stream, payload);
+    const unsubscribeMessage = this.buildMultiplexedMessage(stream, unsubscribePayload);
     const createListenerId = options.create ? this.dispatcher.listen(createSelector, handler) : null;
     const updateListenerId = this.dispatcher.listen(updateSelector, handler);
     const deleteListenerId = this.dispatcher.listen(deleteSelector, handler);

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -228,10 +228,10 @@ interface IStreamingAPI {
    * @param stream Name of object's type stream
    * @param data Extra data to send to API
    * @param requestId Optional value in the payload to send as request_id to the server.
-   *                  If not specified, one will be generated.
+   *     If not specified, one will be generated.
    * @return Promise resolves/rejects when response to list request received.
-   *         On success, the promise will be resolved with list of objects.
-   *         On failure, the promise will be rejected with the entire API response.
+   *     On success, the promise will be resolved with list of objects.
+   *     On failure, the promise will be rejected with the entire API response.
    */
   list(stream: string, data?: object, requestId?: string): Promise<object>;
 
@@ -241,10 +241,10 @@ interface IStreamingAPI {
    * @param stream Name of object's type stream
    * @param props Attributes to create on object
    * @param requestId Optional value in the payload to send as request_id to the server.
-   *                  If not specified, one will be generated.
+   *     If not specified, one will be generated.
    * @return Promise resolves/rejects when response to creation request received.
-   *         On success, the promise will be resolved with the created object.
-   *         On failure, the promise will be rejected with the entire API response.
+   *     On success, the promise will be resolved with the created object.
+   *     On failure, the promise will be rejected with the entire API response.
    */
   create(stream: string, props: object, requestId?: string): Promise<object>;
 
@@ -255,10 +255,10 @@ interface IStreamingAPI {
    * @param pk ID of object to retrieve
    * @param data Extra data to send to API
    * @param requestId Optional value in the payload to send as request_id to the server.
-   *                  If not specified, one will be generated.
+   *     If not specified, one will be generated.
    * @return Promise resolves/rejects when response to retrieval request received.
-   *         On success, the promise will be resolved with the retrieved object.
-   *         On failure, the promise will be rejected with the entire API response.
+   *     On success, the promise will be resolved with the retrieved object.
+   *     On failure, the promise will be rejected with the entire API response.
    */
   retrieve(stream: string, pk: number, data?: object, requestId?: string): Promise<object>;
 
@@ -269,10 +269,10 @@ interface IStreamingAPI {
    * @param pk ID of object to update
    * @param props Attributes to patch on object
    * @param requestId Optional value in the payload to send as request_id to the server.
-   *                  If not specified, one will be generated.
+   *    If not specified, one will be generated.
    * @return Promise resolves/rejects when response to update request received.
-   *         On success, the promise will be resolved with the updated object.
-   *         On failure, the promise will be rejected with the entire API response.
+   *     On success, the promise will be resolved with the updated object.
+   *     On failure, the promise will be rejected with the entire API response.
    */
   update(stream: string, pk: number, props: object, requestId?: string): Promise<object>;
 
@@ -283,10 +283,10 @@ interface IStreamingAPI {
    * @param pk ID of object to update
    * @param props Attributes to patch on object
    * @param requestId Optional value in the payload to send as request_id to the server.
-   *                  If not specified, one will be generated.
+   *    If not specified, one will be generated.
    * @return Promise resolves/rejects when response to update request received.
-   *         On success, the promise will be resolved with the updated object.
-   *         On failure, the promise will be rejected with the entire API response.
+   *    On success, the promise will be resolved with the updated object.
+   *    On failure, the promise will be rejected with the entire API response.
    */
   patch(stream: string, pk: number, props: object, requestId?: string): Promise<object>;
 
@@ -297,40 +297,94 @@ interface IStreamingAPI {
    * @param pk ID of object to delete
    * @param data Extra data to send to API
    * @param requestId Optional value in the payload to send as request_id to the server.
-   *                  If not specified, one will be generated.
+   *    If not specified, one will be generated.
    * @return Promise resolves/rejects when response to deletion request received.
-   *         On success, the promise will be resolved with null, or an empty object.
-   *         On failure, the promise will be rejected with the entire API response.
+   *    On success, the promise will be resolved with null, or an empty object.
+   *    On failure, the promise will be rejected with the entire API response.
    */
   delete(stream: string, pk: number, data?: object, requestId?: string): Promise<object | null>;
 
   /**
-   * Subscribe to updates
+   * Subscribe to update and delete events for an object, or perform a custom subscription
    *
    * @param stream Name of object's type stream
-   * @param args ID of specific DB object to watch.
+   * @param pk ID of specific DB object to watch
    * @param callback Function to call with payload on new events
-   * @param options Optional object that may contain several optional properties.
-   *                requestId is a string property that provides a way to override the request id for messages related to this subscription.
-   *                If not specified, one will be generated.
-   *                subscribeAction is the action name string the subscribe request be sent to.
-   *                If not specified, subscribeAction will be 'subscribe_instance'.
-   *                unsubscribeAction is the action name string the unsubscribe request be sent to.
-   *                If not specified, unsubscribeAction will be 'unsubscribe_instance'.
-   *                create is a boolean property that lets subscribe know it should listen for create events.
-   *                If not specified, create is false.
-   *                options can also be a requestId string directly, for backwards compatibility.
-   * @return Promise resolves/rejects when response to subscription request received.
-   *         On success, the promise will be resolved with null, or an empty object.
-   *         On failure, the promise will be rejected with the entire API response.
-   *         This Promise has an additional method, cancel(), which can be called
-   *         to cancel the subscription.
+   * @param options Optional object to configure the subscription
+   * @param options.requestId Specific request ID to submit with the
+   *    subscription/unsubscription request, and which will be included in
+   *    responses from DCRF. If not specified, one will be automatically generated.
+   * @param options.subscribeAction Name of action used in subscription request.
+   *    By default, 'subscribe_instance' is used.
+   * @param options.unsubscribeAction Name of action used in unsubscription request.
+   *    By default, 'unsubscribe_instance' is used.
+   * @param options.includeCreateEvents Whether to listen for creation events,
+   *    in addition to updates and deletes. By default, this is false.
+   * @return Promise Resolves/rejects when response to subscription request received.
+   *    On success, the promise will be resolved with null, or an empty object.
+   *    On failure, the promise will be rejected with the entire API response.
+   *    This Promise has an additional method, cancel(), which can be called
+   *    to cancel the subscription.
    */
-  subscribe(stream: string,
-            args: object | number,
-            callback: SubscriptionHandler,
-            options?: SubscribeOptions | string,
-  ): CancelablePromise<object | null>;
+  subscribe(stream: string, pk: number, callback: SubscriptionHandler, options?: SubscribeOptions): CancelablePromise<object | null>;
+
+  /**
+   * Subscribe to update and delete events for an object, or perform a custom subscription
+   *
+   * @param stream Name of object's type stream
+   * @param pk ID of specific DB object to watch
+   * @param callback Function to call with payload on new events
+   * @param requestId Specific request ID to submit with the subscription/unsubscription
+   *    request, and which will be included in responses from DCRF.
+   *    If not specified, one will be automatically generated.
+   * @return Promise Resolves/rejects when response to subscription request received.
+   *    On success, the promise will be resolved with null, or an empty object.
+   *    On failure, the promise will be rejected with the entire API response.
+   *    This Promise has an additional method, cancel(), which can be called
+   *    to cancel the subscription.
+   */
+  subscribe(stream: string, pk: number, callback: SubscriptionHandler, requestId?: string): CancelablePromise<object | null>;
+
+  /**
+   * Subscribe to update and delete events for an object, or perform a custom subscription
+   *
+   * @param stream Name of object's type stream
+   * @param args Identifying information to be included in subscription request
+   * @param callback Function to call with payload on new events
+   * @param options Optional object to configure the subscription
+   * @param options.requestId Specific request ID to submit with the
+   *    subscription/unsubscription request, and which will be included in
+   *    responses from DCRF. If not specified, one will be automatically generated.
+   * @param options.subscribeAction Name of action used in subscription request.
+   *    By default, 'subscribe_instance' is used.
+   * @param options.unsubscribeAction Name of action used in unsubscription request.
+   *    By default, 'unsubscribe_instance' is used.
+   * @param options.includeCreateEvents Whether to listen for creation events,
+   *    in addition to updates and deletes. By default, this is false.
+   * @return Promise Resolves/rejects when response to subscription request received.
+   *    On success, the promise will be resolved with null, or an empty object.
+   *    On failure, the promise will be rejected with the entire API response.
+   *    This Promise has an additional method, cancel(), which can be called
+   *    to cancel the subscription.
+   */
+  subscribe(stream: string, args: object, callback: SubscriptionHandler, options?: SubscribeOptions): CancelablePromise<object | null>;
+
+  /**
+   * Subscribe to update and delete events for an object, or perform a custom subscription
+   *
+   * @param stream Name of object's type stream
+   * @param args Identifying information to be included in subscription request
+   * @param callback Function to call with payload on new events
+   * @param requestId Specific request ID to submit with the subscription/unsubscription
+   *    request, and which will be included in responses from DCRF.
+   *    If not specified, one will be automatically generated.
+   * @return Promise Resolves/rejects when response to subscription request received.
+   *    On success, the promise will be resolved with null, or an empty object.
+   *    On failure, the promise will be rejected with the entire API response.
+   *    This Promise has an additional method, cancel(), which can be called
+   *    to cancel the subscription.
+   */
+  subscribe(stream: string, args: object, callback: SubscriptionHandler, requestId?: string): CancelablePromise<object | null>;
 
   /**
    * Cancel all subscriptions
@@ -345,11 +399,11 @@ interface IStreamingAPI {
    *
    * @param stream Name of object's type stream
    * @param payload Data to send as payload
-   * @param requestId Value to send as request_id to the server. If not
-   *                  specified, one will be generated.
+   * @param requestId Value to send as request_id to the server. If not specified,
+   *    one will be generated.
    * @return Promise resolves/rejects when response received.
-   *         On success, the promise will be resolved with response.data.
-   *         On failure, the promise will be rejected with the entire API response.
+   *    On success, the promise will be resolved with response.data.
+   *    On failure, the promise will be rejected with the entire API response.
    */
   request(stream: string, payload: object, requestId?: string): Promise<object>;
 }
@@ -361,10 +415,10 @@ interface IStreamingAPI {
  *
  * @param stream Name of object's type stream
  * @param payload Data which will be sent as payload. This may be mutated, as
- *                long as no value is then returned from the callback.
+ *    long as no value is then returned from the callback.
  * @param requestId Value in the payload sent as request_id to the server.
  * @return undefined to send the same payload object as passed in; or a new
- *         Object to be sent instead.
+ *    Object to be sent instead.
  *
  */
 export type PayloadPreprocessor = (stream: string, payload: object, requestId: string) => object | null;
@@ -376,7 +430,7 @@ export type PayloadPreprocessor = (stream: string, payload: object, requestId: s
  *
  * @param message The message to be sent over the wire to the server.
  * @return undefined to send the same message object as passed in (and
- *         potentially mutated); or an Object to be sent instead.
+ *    potentially mutated); or an Object to be sent instead.
  */
 export type MessagePreprocessor = (message: object) => object | undefined;
 

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -162,7 +162,7 @@ interface ICancelable {
   /**
    * @return true if canceled, false if already canceled.
    */
-  cancel(): boolean;
+  cancel(): Promise<boolean>;
 }
 
 
@@ -469,6 +469,7 @@ export type SubscribeDeleteSelectorBuilder = (stream: string, requestId: string)
  * @param requestId The request ID to use in the subscription request
  */
 export type SubscribePayloadBuilder = (action: string, args: object, requestId: string) => object;
+export type UnsubscribePayloadBuilder = (action: string, args: object, requestId: string) => object;
 
 
 export
@@ -490,6 +491,7 @@ interface IDCRFOptions {
   buildSubscribeUpdateSelector?: SubscribeUpdateSelectorBuilder,
   buildSubscribeDeleteSelector?: SubscribeDeleteSelectorBuilder,
   buildSubscribePayload?: SubscribePayloadBuilder,
+  buildUnsubscribePayload?: UnsubscribePayloadBuilder,
 
   // ReconnectingWebsocket options
   websocket?: ReconnectingWebsocketOptions

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -172,7 +172,7 @@ export type SubscribeOptions = {
   requestId?: string,
   subscribeAction?: string,
   unsubscribeAction?: string,
-  create?: boolean,
+  includeCreateEvents?: boolean,
 }
 
 export type SubscriptionAction = 'create' | 'update' | 'delete';

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -192,8 +192,10 @@ interface IStreamingAPI {
    * Close the connection.
    *
    * @param unsubscribe Whether to cancel all subscriptions, as well. Defaults to true.
+   * @return Promise Resolves when all unsubscription requests have completed, or
+   *    immediately if unsubscribe=false
    */
-  close(unsubscribe?: boolean): void;
+  close(unsubscribe?: boolean): Promise<any>;
 
   /**
    * The name of the primary key field, used to identify objects for subscriptions.

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -333,9 +333,10 @@ interface IStreamingAPI {
   /**
    * Cancel all subscriptions
    *
-   * @return The number of subscriptions canceled.
+   * @return Promise resolving when all unsubscription requests have completed,
+   *    with a value representing the number of listeners removed.
    */
-  unsubscribeAll(): number;
+  unsubscribeAll(): Promise<number>;
 
   /**
    * Perform an asynchronous transaction

--- a/src/lib/UUID.ts
+++ b/src/lib/UUID.ts
@@ -10,7 +10,7 @@ class UUID {
   private static readonly lut: string[] = [];
 
   private static initialize(): void {
-    for (var i = 0; i < 256; i++) {
+    for (let i = 0; i < 256; i++) {
       this.lut[i] = (i < 16 ? '0' : '') + (i).toString(16);
     }
   }

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,0 +1,23 @@
+import { createLogger, format, transports } from 'winston';
+
+export
+const rootLogger = createLogger({
+  format: format.combine(
+    format.splat(),
+    format.timestamp({ format: 'YYYY-mm-dd HH:MM:SS' }),
+    format.printf(info => {
+      const label = info.label || '<root>';
+      const { timestamp: ts, message: msg, level } = info;
+      return `[${ts}][${label}][${level}] ${msg}`;
+    }),
+  ),
+  transports: [
+    new transports.Console(),
+  ],
+});
+
+
+export
+const getLogger = (name: string) => rootLogger.child({
+  label: name,
+});

--- a/src/send_queues/fifo.ts
+++ b/src/send_queues/fifo.ts
@@ -1,6 +1,6 @@
 import autobind from 'autobind-decorator';
-import { getLogger } from 'loglevel';
 
+import { getLogger } from '../logging';
 import { ISendQueue } from '../interface';
 import BaseSendQueue from './base';
 
@@ -19,6 +19,7 @@ class FifoQueue extends BaseSendQueue implements ISendQueue {
   @autobind
   public send(bytes: string): number {
     if (this.canSend()) {
+      log.debug(`Sending bytes over the wire: ${bytes}`);
       return this.sendNow(bytes);
     } else {
       this.queueMessage(bytes);

--- a/src/subscriptions.ts
+++ b/src/subscriptions.ts
@@ -6,12 +6,10 @@
  */
 export
 class SubscriptionPromise<T> extends Promise<T> {
-  protected unsubscribe: () => boolean;
+  protected unsubscribe: () => Promise<boolean>;
 
-  constructor(executor: (resolve: (value?: T | PromiseLike<T>) => void,
-                         reject: (reason?: any) => void
-                        ) => void,
-              unsubscribe: () => boolean) {
+  constructor(executor: (resolve: (value?: (PromiseLike<T> | T)) => void, reject: (reason?: any) => void) => void,
+                unsubscribe: () => Promise<boolean>) {
     super(executor);
     this.unsubscribe = unsubscribe;
   }
@@ -20,7 +18,7 @@ class SubscriptionPromise<T> extends Promise<T> {
    * Stop listening for new events on this subscription
    * @return true if the subscription was active, false if it was already unsubscribed
    */
-  public cancel(): boolean {
-    return this.unsubscribe();
+  public async cancel(): Promise<boolean> {
+    return await this.unsubscribe();
   }
 }

--- a/src/transports/websocket.ts
+++ b/src/transports/websocket.ts
@@ -1,8 +1,8 @@
-import {getLogger} from 'loglevel';
 import {EventEmitter} from 'events';
 import ReconnectingWebsocket, { Event } from 'reconnecting-websocket';
 import autobind from 'autobind-decorator';
 
+import { getLogger } from '../logging';
 import {ITransport} from '../interface';
 
 

--- a/test/integration/dcrf_client_test/consumers.py
+++ b/test/integration/dcrf_client_test/consumers.py
@@ -1,17 +1,22 @@
 import logging
+from functools import partial
+from typing import Iterable, Union
 
+from djangochannelsrestframework.decorators import action
 from djangochannelsrestframework.generics import GenericAsyncAPIConsumer
 from djangochannelsrestframework.mixins import (
+    CreateModelMixin,
+    DeleteModelMixin,
     ListModelMixin,
     PatchModelMixin,
     UpdateModelMixin,
-    CreateModelMixin,
-    DeleteModelMixin,
 )
 from djangochannelsrestframework.observer.generics import ObserverModelInstanceMixin
-from rest_framework import serializers
+from rest_framework import serializers, status
+from rest_framework.exceptions import NotFound
 
 from dcrf_client_test.models import Thing
+from dcrf_client_test.observers import model_observer
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +48,82 @@ class ThingConsumer(
 ):
     queryset = Thing.objects.all()
     serializer_class = ThingSerializer
+
+    def _unsubscribe(self, request_id: str):
+        request_id_found = False
+        to_remove = []
+        for group, request_ids in self.subscribed_requests.items():
+            if request_id in request_ids:
+                request_id_found = True
+                request_ids.remove(request_id)
+            if not request_ids:
+                to_remove.append(group)
+
+        if not request_id_found:
+            raise KeyError(request_id)
+
+        for group in to_remove:
+            del self.subscribed_requests[group]
+
+    @action()
+    async def unsubscribe_instance(self, request_id=None, **kwargs):
+        try:
+            return await super().unsubscribe_instance(request_id=request_id, **kwargs)
+        except KeyError:
+            raise NotFound(detail='Subscription not found')
+
+    @model_observer(Thing)
+    async def on_thing_activity(
+        self, message, observer=None, action: str = None, request_id: str = None, **kwargs
+    ):
+        try:
+            reply = partial(self.reply, action=action, request_id=request_id)
+
+            if action == 'delete':
+                await reply(data=message, status=204)
+                # send the delete
+                return
+
+            # the @action decorator will wrap non-async action into async ones.
+            response = await self.retrieve(
+                request_id=request_id, action=action, **message
+            )
+
+            if isinstance(response, tuple):
+                data, status = response
+            else:
+                data, status = response, 200
+            await reply(data=data, status=status)
+        except Exception as exc:
+            await self.handle_exception(exc, action=action, request_id=request_id)
+
+    @on_thing_activity.groups_for_signal
+    def on_thing_activity(self, instance: Thing, **kwargs):
+        yield f'-pk__{instance.pk}'
+        yield f'-all'
+
+    @on_thing_activity.groups_for_consumer
+    def on_thing_activity(self, things: Iterable[Union[Thing, int]] = None, **kwargs):
+        if things is None:
+            yield f'-all'
+        else:
+            for thing in things:
+                thing_id = thing.pk if isinstance(thing, Thing) else thing
+                yield f'-pk__{thing_id}'
+
+    @on_thing_activity.serializer
+    def on_thing_activity(self, instance: Thing, action: str, **kwargs):
+        return ThingSerializer(instance).data
+
+    @action()
+    async def subscribe_many(self, request_id: str = None, things: Iterable[int] = None, **kwargs):
+        await self.on_thing_activity.subscribe(request_id=request_id, things=things)
+        return None, status.HTTP_201_CREATED
+
+    @action()
+    async def unsubscribe_many(self, request_id: str = None, things: Iterable[int] = None, **kwargs):
+        await self.on_thing_activity.unsubscribe(request_id=request_id, things=things)
+        return None, status.HTTP_204_NO_CONTENT
 
 
 class ThingsWithIdConsumer(ThingConsumer):

--- a/test/integration/dcrf_client_test/demultiplexer.py
+++ b/test/integration/dcrf_client_test/demultiplexer.py
@@ -1,0 +1,26 @@
+from channelsmultiplexer import (
+    AsyncJsonWebsocketDemultiplexer as BaseAsyncJsonWebsocketDemultiplexer,
+)
+
+
+class AsyncJsonWebsocketDemultiplexer(BaseAsyncJsonWebsocketDemultiplexer):
+    async def websocket_accept(self, message, stream_name):
+        is_last = self.applications_accepting_frames == set(self.applications) - {stream_name}
+        self.applications_accepting_frames.add(stream_name)
+
+        ###
+        # accept the connection after the *last* upstream application accepts.
+        #
+        # channelsmultiplexer's implementation of websocket_accept will accept
+        # the websocket connection when the _first_ upstream application accepts.
+        # This can get hairy during tests, as the client can only judge a websocket's
+        # readiness by whether the connection has been accepted — if the test is
+        # making requests against the second stream, but only the first stream
+        # is "accepting frames", there *will* be "Invalid multiplexed frame received
+        # (stream not mapped)" errors.
+        #
+        # To combat this, we only accept the websocket connection when *all* the
+        # streams' applications are ready. The default behaviour may be a bug.
+        #
+        if is_last:
+            await self.accept()

--- a/test/integration/dcrf_client_test/observers.py
+++ b/test/integration/dcrf_client_test/observers.py
@@ -1,0 +1,60 @@
+from collections import defaultdict
+from functools import partial
+from typing import Dict, Iterable, Set, Type
+
+from django.db.models import Model
+from djangochannelsrestframework.consumers import AsyncAPIConsumer
+from djangochannelsrestframework.observer import ModelObserver
+
+
+class RequestIdModelObserver(ModelObserver):
+    """ModelObserver which keeps track of each subscription's request_id"""
+
+    def __init__(self, func, model_cls: Type[Model], partition: str = "*", **kwargs):
+        self.group_request_ids: Dict[str, Set[str]] = defaultdict(set)
+        self.request_id_groups: Dict[str, Set[str]] = defaultdict(set)
+        super().__init__(func, model_cls, partition, **kwargs)
+
+    async def __call__(self, message, consumer=None, **kwargs):
+        group = message.pop('group')
+
+        for request_id in self.group_request_ids[group]:
+            return await super().__call__(message, consumer, request_id=request_id)
+
+    async def subscribe(
+        self, consumer: AsyncAPIConsumer, *args, request_id: str = None, **kwargs
+    ) -> Iterable[str]:
+        if request_id is None:
+            raise ValueError("request_id must have a value set")
+
+        groups = await super().subscribe(consumer, *args, **kwargs)
+
+        for group in groups:
+            self.group_request_ids[group].add(request_id)
+
+        self.request_id_groups[request_id].update(groups)
+
+        return groups
+
+    async def unsubscribe(
+        self, consumer: AsyncAPIConsumer, *args, request_id: str = None, **kwargs
+    ) -> Iterable[str]:
+        if request_id is None:
+            raise ValueError("request_id must have a value set")
+
+        groups = await super().unsubscribe(consumer, *args, **kwargs)
+
+        for group in self.request_id_groups[request_id]:
+            group_request_ids = self.group_request_ids[group]
+            group_request_ids.discard(request_id)
+
+            if not group_request_ids:
+                del self.group_request_ids[group]
+
+        del self.request_id_groups[request_id]
+
+        return groups
+
+
+def model_observer(model, **kwargs):
+    return partial(RequestIdModelObserver, model_cls=model, kwargs=kwargs)

--- a/test/integration/dcrf_client_test/routing.py
+++ b/test/integration/dcrf_client_test/routing.py
@@ -1,9 +1,9 @@
 from channels.routing import ProtocolTypeRouter, URLRouter
-from channelsmultiplexer import AsyncJsonWebsocketDemultiplexer
 from django.core.asgi import get_asgi_application
 from django.urls import path
 
 from dcrf_client_test.consumers import ThingConsumer, ThingsWithIdConsumer
+from dcrf_client_test.demultiplexer import AsyncJsonWebsocketDemultiplexer
 
 application = ProtocolTypeRouter({
     'websocket': URLRouter([

--- a/test/integration/tests/live_server.py
+++ b/test/integration/tests/live_server.py
@@ -44,15 +44,12 @@ class LiveServer:
     def get_application(self):
         from django.conf import settings
 
+        application = get_default_application()
+
         if "django.contrib.staticfiles" in settings.INSTALLED_APPS:
-            application = self.static_wrapper(get_default_application())
-        else:
-            application = get_default_application()
+            application = self.static_wrapper(application)
 
         return application
-
-    def reload_application(self):
-        self._server_process.application = self.get_application()
 
     def stop(self):
         """Stop the server"""

--- a/test/integration/tests/mocha.py
+++ b/test/integration/tests/mocha.py
@@ -152,7 +152,6 @@ class MochaTest(pytest.Function):
     def _testmethod(self, live_server: LiveServer, **kwargs):
         coordinator.expect('test')
 
-        live_server.reload_application()
         coordinator.write('server info', url=live_server.url, ws_url=live_server.ws_url)
 
         event = coordinator.expect('pass', 'fail')

--- a/test/integration/tests/mocha.py
+++ b/test/integration/tests/mocha.py
@@ -156,6 +156,10 @@ class MochaTest(pytest.Function):
         coordinator.write('server info', url=live_server.url, ws_url=live_server.ws_url)
 
         event = coordinator.expect('pass', 'fail')
+
+        # Wait for all mocha after/afterEach hooks to complete
+        coordinator.expect('test end')
+
         if event['state'] == 'failed':
             message = event['err']
             stack = event['stack']

--- a/test/integration/tests/test.ts
+++ b/test/integration/tests/test.ts
@@ -2,12 +2,33 @@ import fs from "fs";
 
 import chai, {expect} from 'chai';
 import chaiSubset from 'chai-subset';
+import {format, transports} from 'winston';
 chai.use(chaiSubset);
+
+import {rootLogger, getLogger} from '../../../src/logging';
+
+// Enable all logging
+rootLogger.level = 'debug';
+// Print all logs to stderr, so pytest may parrot them
+rootLogger
+  .clear()
+  .add(new transports.Console({
+    level: 'silly',
+    stderrLevels: Object.keys(rootLogger.levels),
+  }));
+// And colorize, for style
+rootLogger.format = format.combine(
+  format.colorize(),
+  rootLogger.format,
+);
 
 import WebSocket from 'ws';
 
 import dcrf, {DCRFClient} from '../../../src/';
 import {DCRFGlobal} from '../../global';
+
+
+const log = getLogger('dcrf.test.integration');
 
 
 declare const global: DCRFGlobal;


### PR DESCRIPTION
This PR is intended to supersede #11, and builds atop the wonderful (and for many months, thankless) contributions from @jhillacre

Fixes #10
Closes #9 


# Brief

This PR adds support for custom subscription actions through `.subscribe()`, and changes `SubscriptionPromise.cancel()`, `.close()`, and `.unsubscribeAll()` to return Promises that resolve upon completion.

Also, this PR switches logging from loglevel to winston, because it offered the configurability I wasn't finding from loglevel.


# Description

## subscribe()
To support custom subscription actions, the prototype for `subscribe()` has been modified. It now accepts an `options` object, allowing `subscribeAction: 'my_custom_subscribe'` and `unsubscribeAction: 'my_custom_unsubscribe'` to be passed. `includeCreateEvents: true` may also be passed in options, instructing the client to also listen for `"action": "create"` events over the wire. Additionally, an arbitrary object may be passed in place of `pk`, enabling custom arguments to be passed to the action.

```ts
/**
 * Subscribe to update and delete events for an object, or perform a custom subscription
 *
 * @param stream Name of object's type stream
 * @param args Identifying information to be included in subscription request
 * @param callback Function to call with payload on new events
 * @param options Optional object to configure the subscription
 * @param options.requestId Specific request ID to submit with the
 *    subscription/unsubscription request, and which will be included in
 *    responses from DCRF. If not specified, one will be automatically generated.
 * @param options.subscribeAction Name of action used in subscription request.
 *    By default, 'subscribe_instance' is used.
 * @param options.unsubscribeAction Name of action used in unsubscription request.
 *    By default, 'unsubscribe_instance' is used.
 * @param options.includeCreateEvents Whether to listen for creation events,
 *    in addition to updates and deletes. By default, this is false.
 * @return Promise Resolves/rejects when response to subscription request received.
 *    On success, the promise will be resolved with null, or an empty object.
 *    On failure, the promise will be rejected with the entire API response.
 *    This Promise has an additional method, cancel(), which can be called
 *    to cancel the subscription.
 */
subscribe(stream: string, args: object, callback: SubscriptionHandler, options?: SubscribeOptions): CancelablePromise<object | null>;
```


## SubscriptionPromise.cancel() / close() / unsubscribeAll()
These three methods have been changed to return Promises that resolve when their actions are completed. 

Many moons ago, DCRF (or CRF?) didn't support unsubscribing, so no requests were sent to the server upon canceling a subscription — the client would simply ignore those unsubscribed events. However — also many moons ago :sweat_smile: — DCRF added support for unsubscribing, so there grew a good reason for dcrf-client to wait for those unsubscription requests to complete. @jhillacre converted `SubscriptionPromise.cancel()` to a Promise in #11 to cover that case.

In this PR, I've also converted `client.close()` and `client.unsubscribeAll()` to return Promises — though, my main motivation for this was to ensure all subscriptions from one test were cleaned up before the next one ran.


## Logging
I believe the initial reason for switching from [loglevel](https://www.npmjs.com/package/loglevel) to [winston](https://www.npmjs.com/package/winston) was loglevel's lack of argument formatting — there was one place I was doing something like `log.debug('Thing is: %s', thing)` and expecting `Thing is: <thing>`, but actually getting `This is: %s <Thing>`.

Upon switching, I enjoyed the option of including colours to the console, which really helped when debugging the integration tests.

However, **it should be noted that I haven't inspected what the logs look like in a browser!** It may spew too much by default... Or it may be printing nothing. It might be worth adding some ability to configure the log levels to dcrf-client.


## Miscellaneous
TypeScript was upgraded to 3.7+ to gain support for optional chaining (`a?.b?.c` instead of `a && a.b && a.b.c`) and nullish coalescing (`a ?? b` instead of `a == null ? b : a`), because I believe it makes the code more succinct and easier to read.