### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,35 @@
+name: Integration tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip pipenv
+        pipenv install --dev
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Install redis-server
+      uses: shogo82148/actions-setup-redis@v1
+      with:
+        redis-version: '6.x'
+        auto-start: false
+    - run: npm ci
+    - run: npm run test:integration
+

--- a/.github/workflows/mocha.yml
+++ b/.github/workflows/mocha.yml
@@ -1,0 +1,26 @@
+name: Mocha tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x, 15.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm ci
+    - run: npm run test:unit
+

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "prepare": "npm run build",
     "test": "npm run test:unit; npm run test:integration",
     "test:unit": "mocha",
-    "test:integration": "pipenv run py.test || true"
+    "test:integration": "pipenv run py.test"
   },
   "repository": {
     "type": "git",

--- a/test/integration/tests/mocha.py
+++ b/test/integration/tests/mocha.py
@@ -231,6 +231,13 @@ def pytest_collection(session: pytest.Session):
 
             session.items.append(test)
 
+    ###
+    # NOTE: if this counter remains 0 at end of session, an exit code of 5 will be returned.
+    #       This value is normally set by Session.perform_collect(), but we are bypassing that
+    #       implementation.
+    #
+    session.testscollected = len(session.items)
+
     return session.items
 
 


### PR DESCRIPTION
This PR does a couple things I should've done long ago:

 - Figured out and resolved why pytest returns with exit code 5 (it thinks no tests were collected, because `Session.itemscollected` wasn't being set)
 - Add automated testing. GitHub Actions is actually pretty damn easy to use.

---

Next up, I'd really like to add some tests that use webpack to package dcrf-client, so issues like #27 would be caught before publishing to npm.