### PR TITLE
Streaming pagination support (streamingRequest)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "chai": "^4.2.0",
         "chai-subset": "^1.6.0",
         "deasync": "^0.1.14",
+        "flush-promises": "^1.0.2",
         "mocha": "^8.2.1",
         "sinon": "^7.3.1",
         "sinon-chai": "^3.3.0",
@@ -1116,6 +1117,12 @@
       "bin": {
         "flat": "cli.js"
       }
+    },
+    "node_modules/flush-promises": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/flush-promises/-/flush-promises-1.0.2.tgz",
+      "integrity": "sha512-G0sYfLQERwKz4+4iOZYQEZVpOt9zQrlItIxQAAYAWpfby3gbHrx0osCHz5RLl/XoXevXk0xoN4hDFky/VV9TrA==",
+      "dev": true
     },
     "node_modules/fn.name": {
       "version": "1.1.0",
@@ -3643,6 +3650,12 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
       "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true
+    },
+    "flush-promises": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/flush-promises/-/flush-promises-1.0.2.tgz",
+      "integrity": "sha512-G0sYfLQERwKz4+4iOZYQEZVpOt9zQrlItIxQAAYAWpfby3gbHrx0osCHz5RLl/XoXevXk0xoN4hDFky/VV9TrA==",
       "dev": true
     },
     "fn.name": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "chai": "^4.2.0",
     "chai-subset": "^1.6.0",
     "deasync": "^0.1.14",
+    "flush-promises": "^1.0.2",
     "mocha": "^8.2.1",
     "sinon": "^7.3.1",
     "sinon-chai": "^3.3.0",
@@ -64,8 +65,8 @@
     "autobind-decorator": "^2.4.0",
     "lodash.ismatch": "^4.4.0",
     "lodash.pull": "^4.1.0",
-    "reconnecting-websocket": "^4.4.0",
     "lodash.uniqby": "^4.7.0",
+    "reconnecting-websocket": "^4.4.0",
     "winston": "^3.3.3"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -300,7 +300,7 @@ class DCRFClient implements IStreamingAPI {
     });
   }
 
-  public requestMultiple(stream: string, payload: object, requestId: string = UUID.generate(), callback: RequestMultipleHandler): RequestMultipleCancel {
+  public requestMultiple(stream: string, payload: object, callback: RequestMultipleHandler, requestId: string = UUID.generate()): RequestMultipleCancel {
     const selector = this.buildRequestResponseSelector(stream, requestId);
 
     const listenerId = this.dispatcher.listen(selector, (data: typeof selector & { payload: { response_status: number, data: any } }) => {

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -411,6 +411,8 @@ interface IStreamingAPI {
    *    On failure, the promise will be rejected with the entire API response.
    */
   request(stream: string, payload: object, requestId?: string): Promise<object>;
+
+  requestMultiple(stream: string, payload: object, callback:RequestMultipleHandler, requestId?: string): RequestMultipleCancel;
 }
 
 

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -11,6 +11,11 @@ type DispatchListener<T> = (response: T) => any;
 export
 type SubscriptionHandler = (payload: {[prop: string]: any}, action: string) => any;
 
+export
+type RequestMultipleHandler = (error: {response_status: number, data: any} | null, payload: {[prop: string]: any} | null) => any;
+
+export
+type RequestMultipleCancel = () => void;
 
 /**
  * Calls all handlers whose selectors match an incoming payload.

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -14,9 +14,6 @@ type SubscriptionHandler = (payload: {[prop: string]: any}, action: string) => a
 export
 type StreamingRequestHandler = (error: {response_status: number, data: any} | null, payload: {[prop: string]: any} | null) => any;
 
-export
-type StreamingRequestCanceler = () => Promise<boolean>;
-
 
 /**
  * Calls all handlers whose selectors match an incoming payload.
@@ -423,7 +420,7 @@ interface IStreamingAPI {
    *    one will be generated.
    * @return StreamingRequestCanceler function to call when deciding there will be no more responses.
    */
-  streamingRequest(stream: string, payload: object, callback: StreamingRequestHandler, requestId?: string): StreamingRequestCanceler;
+  streamingRequest(stream: string, payload: object, callback: StreamingRequestHandler, requestId?: string): CancelablePromise<void>;
 }
 
 

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -12,10 +12,11 @@ export
 type SubscriptionHandler = (payload: {[prop: string]: any}, action: string) => any;
 
 export
-type RequestMultipleHandler = (error: {response_status: number, data: any} | null, payload: {[prop: string]: any} | null) => any;
+type StreamingRequestHandler = (error: {response_status: number, data: any} | null, payload: {[prop: string]: any} | null) => any;
 
 export
-type RequestMultipleCancel = () => void;
+type StreamingRequestCanceler = () => Promise<boolean>;
+
 
 /**
  * Calls all handlers whose selectors match an incoming payload.
@@ -412,7 +413,17 @@ interface IStreamingAPI {
    */
   request(stream: string, payload: object, requestId?: string): Promise<object>;
 
-  requestMultiple(stream: string, payload: object, callback:RequestMultipleHandler, requestId?: string): RequestMultipleCancel;
+  /**
+   * Perform an asynchronous transaction where the result can be broken into multiple responses
+   *
+   * @param stream Name of object's type stream
+   * @param payload Data to send as payload
+   * @param callback Function to call with payload on new responses
+   * @param requestId Value to send as request_id to the server. If not specified,
+   *    one will be generated.
+   * @return StreamingRequestCanceler function to call when deciding there will be no more responses.
+   */
+  streamingRequest(stream: string, payload: object, callback: StreamingRequestHandler, requestId?: string): StreamingRequestCanceler;
 }
 
 

--- a/test/test.ts
+++ b/test/test.ts
@@ -352,7 +352,7 @@ describe('DCRFClient', function() {
     });
   });
 
-    describe('subscribe', function() {
+  describe('subscribe', function() {
     it('invokes callback on every update', function() {
       const id = 1337;
       const requestId = 'fake-request-id';


### PR DESCRIPTION
This PR adds a method to `DCRFClient`, allowing for a single request to listening for responses until the returned cancel function is called. The intention of creating this method is to support streaming pagination from `djangochannelsrestframework`, as described in #22.